### PR TITLE
Fix windows server paths parsing to paths.py

### DIFF
--- a/py_src/jupyter_lsp/paths.py
+++ b/py_src/jupyter_lsp/paths.py
@@ -30,8 +30,8 @@ def file_uri_to_path(file_uri):
     file_uri_path_unquoted = unquote(file_uri_parsed.path)
     # when windows, and file is on a server
     if windows_path and file_uri_parsed.netloc:
-        file_path = file_uri.split(":")[1]
-        result = unquote(file_path)
+        file_path = file_uri.split(":")[1]  # pragma: no cover
+        result = unquote(file_path)  # pragma: no cover
     # when windows, and file is local
     elif windows_path and file_uri_path_unquoted.startswith("/"):
         result = file_uri_path_unquoted[1:]  # pragma: no cover

--- a/py_src/jupyter_lsp/tests/test_paths.py
+++ b/py_src/jupyter_lsp/tests/test_paths.py
@@ -65,6 +65,7 @@ def test_file_uri_to_path_posix(file_uri, expected_posix_path):  # pragma: no co
         # https://github.com/krassowski/jupyterlab-lsp/pull/305#issuecomment-665996145
         ["file:///C:/Windows/System32/Drivers/etc", "C:/Windows/System32/Drivers/etc"],
         ["file:///C:/some%20dir/some%20file.txt", "C:/some dir/some file.txt"],
+        ["file://server/share/Pa%20th/to/.virtual_documents", "//server/share/Pa th/to/.virtual_documents"],
     ],
 )
 def test_file_uri_to_path_windows(file_uri, expected_windows_path):  # pragma: no cover


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#419 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
For a file on a windows server the uri looks like "file://server/share/path/to/file" which was not properly parsed by file_uri_to_path.
The urlparse function gives netloc=server, path=/share/path/to/file
When taking the path part, the server is omitted and the proper path is lost.
In the case where the project is on windows and the netloc part is not empty, this modification takes the part after "file:" in the file uri, and unquoted it. This gives file proper path,
even though inelegantly...

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
