### PR TITLE
Implement caching of shadow virtual file handles

### DIFF
--- a/py_src/jupyter_lsp/tests/test_virtual_documents_shadow.py
+++ b/py_src/jupyter_lsp/tests/test_virtual_documents_shadow.py
@@ -35,17 +35,6 @@ async def test_read_missing(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_read_deleted(tmp_path):
-    path = tmp_path / "deleted.py"
-    deleted_file = EditableFile(path)
-    path.unlink()
-
-    await deleted_file.read()
-
-    assert deleted_file.lines == [""]
-
-
-@pytest.mark.asyncio
 async def test_apply_change(tmp_path):
     # inserting text
     path = tmp_path / "test.py"

--- a/py_src/jupyter_lsp/tests/test_virtual_documents_shadow.py
+++ b/py_src/jupyter_lsp/tests/test_virtual_documents_shadow.py
@@ -4,8 +4,8 @@ from typing import List
 import pytest
 
 from ..virtual_documents_shadow import (
-    EditableFile,
     FILES_CACHE,
+    EditableFile,
     ShadowFilesystemError,
     close_cached_files,
     extract_or_none,

--- a/py_src/jupyter_lsp/virtual_documents_shadow.py
+++ b/py_src/jupyter_lsp/virtual_documents_shadow.py
@@ -51,6 +51,7 @@ class EditableFile:
 
     @run_on_executor
     def write_lines(self):
+        self.file.seek(0)
         self.file.write("\n".join(self.lines))
         self.file.flush()
 


### PR DESCRIPTION
Opening the PR to trigger CI and see if the speed up is worth fighting for.

## References

Fixes #447.

## Code changes

- [x] Cache file handles instead of opening them each time.
- [ ] Cache invalidation and deletion of unused files on `textDocument/didClose` (TODO)

## User-facing changes

- Potential performance gain, likely only visible for HDD/Widows user

## Backwards-incompatible changes

None

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
