### PR TITLE
fix renaming of file when jumping code

### DIFF
--- a/packages/code-jumpers/src/jumpers/jumper.ts
+++ b/packages/code-jumpers/src/jumpers/jumper.ts
@@ -91,7 +91,7 @@ export abstract class CodeJumper {
 
   private protectFromAccidentalEditing(document_widget: IDocumentWidget) {
     let editor_widget = document_widget as IDocumentWidget<FileEditor>;
-    editor_widget.title.label = editor_widget.title.label + ' (external)';
+    editor_widget.title.label = editor_widget.title.label + '';
     let editor = editor_widget.content.editor;
     let disposable = editor.addKeydownHandler(
       (editor: IEditor, event: KeyboardEvent) => {

--- a/packages/code-jumpers/src/jumpers/jumper.ts
+++ b/packages/code-jumpers/src/jumpers/jumper.ts
@@ -91,7 +91,9 @@ export abstract class CodeJumper {
 
   private protectFromAccidentalEditing(document_widget: IDocumentWidget) {
     let editor_widget = document_widget as IDocumentWidget<FileEditor>;
-    editor_widget.title.label = editor_widget.title.label + '';
+    // We used to adjust `editor_widget.title.label` here but an upstream
+    // bug (https://github.com/jupyterlab/jupyterlab/issues/10856) prevents
+    // us from doing so anymore.
     let editor = editor_widget.content.editor;
     let disposable = editor.addKeydownHandler(
       (editor: IEditor, event: KeyboardEvent) => {


### PR DESCRIPTION
This PR works around the issue #669 as described [here](https://github.com/jupyter-lsp/jupyterlab-lsp/issues/669#issuecomment-981158541), by just removing the renaming of the tab, until there is a way to do it without actually renaming the files and breaking the envrioment:

## References
Solves issue #669

## Code changes
```
$ git diff fix_jumping..upstream/master
diff --git a/packages/code-jumpers/src/jumpers/jumper.ts b/packages/code-jumpers/src/jumpers/jumper.ts
index 4237c7d..714af70 100644
--- a/packages/code-jumpers/src/jumpers/jumper.ts
+++ b/packages/code-jumpers/src/jumpers/jumper.ts
@@ -91,7 +91,7 @@ export abstract class CodeJumper {
 
   private protectFromAccidentalEditing(document_widget: IDocumentWidget) {
     let editor_widget = document_widget as IDocumentWidget<FileEditor>;
-    editor_widget.title.label = editor_widget.title.label + '';
+    editor_widget.title.label = editor_widget.title.label + ' (external)';
     let editor = editor_widget.content.editor;
     let disposable = editor.addKeydownHandler(
       (editor: IEditor, event: KeyboardEvent) => {
```
