### PR TITLE
Fix server extension UI test: migrate config to `ServerApp` as needed

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -331,6 +331,9 @@ jobs:
 
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
+        with:
+          # temporarily pin because of https://github.com/julia-vscode/SymbolServer.jl/issues/225
+          version: '1.6'
 
       - name: Install Julia language server
         run: julia -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="LanguageServer", version="${{ env.JULIA_LANGSERVER }}"))'

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -45,10 +45,11 @@ Create Notebok Server Config
     Set Global Variable    ${PORT}    ${port}
     Set Global Variable    ${URL}    http://localhost:${PORT}${BASE URL}
     Copy File    ${FIXTURES}${/}${NBSERVER CONF}    ${conf}
-    Update Jupyter Config    ${conf}    LabApp
+    Update Jupyter Config    ${conf}    ServerApp
     ...    base_url=${BASE URL}
     ...    port=${PORT}
     ...    token=${TOKEN}
+    Update Jupyter Config    ${conf}    LabApp
     ...    user_settings_dir=${SETTINGS DIR}
     ...    workspaces_dir=${WORKSPACES DIR}
     # should be automatically enabled, so do not enable manually:

--- a/atest/fixtures/jupyter_server_config.json
+++ b/atest/fixtures/jupyter_server_config.json
@@ -1,12 +1,14 @@
 {
   "LabApp": {
+    "log_level": "DEBUG",
+    "open_browser": false
+  },
+  "ServerApp": {
     "tornado_settings": {
       "page_config_data": {
         "buildCheck": false,
         "buildAvailable": false
       }
-    },
-    "log_level": "DEBUG",
-    "open_browser": false
+    }
   }
 }

--- a/python_packages/jupyter_lsp/jupyter_lsp/manager.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/manager.py
@@ -7,10 +7,12 @@ from typing import Dict, Text, Tuple, cast
 import entrypoints
 from jupyter_core.paths import jupyter_config_path
 from jupyter_server.services.config import ConfigManager
+
 try:
     from jupyter_server.transutils import _i18n as _
-except ImportError:
+except ImportError:  # pragma: no cover
     from jupyter_server.transutils import _
+
 from traitlets import Bool
 from traitlets import Dict as Dict_
 from traitlets import Instance

--- a/python_packages/jupyter_lsp/jupyter_lsp/manager.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/manager.py
@@ -7,7 +7,10 @@ from typing import Dict, Text, Tuple, cast
 import entrypoints
 from jupyter_core.paths import jupyter_config_path
 from jupyter_server.services.config import ConfigManager
-from jupyter_server.transutils import _
+try:
+    from jupyter_server.transutils import _i18n as _
+except ImportError:
+    from jupyter_server.transutils import _
 from traitlets import Bool
 from traitlets import Dict as Dict_
 from traitlets import Instance

--- a/python_packages/jupyter_lsp/jupyter_lsp/types.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/types.py
@@ -20,7 +20,10 @@ from typing import (
     Union,
 )
 
-from jupyter_server.transutils import _
+try:
+    from jupyter_server.transutils import _i18n as _
+except ImportError:
+    from jupyter_server.transutils import _
 from traitlets import Instance
 from traitlets import List as List_
 from traitlets import Unicode, default

--- a/python_packages/jupyter_lsp/jupyter_lsp/types.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/types.py
@@ -22,7 +22,7 @@ from typing import (
 
 try:
     from jupyter_server.transutils import _i18n as _
-except ImportError:
+except ImportError:  # pragma: no cover
     from jupyter_server.transutils import _
 from traitlets import Instance
 from traitlets import List as List_


### PR DESCRIPTION
An attempt to fix issues on CI seen when configuring/reconnecting to JupyterServer https://github.com/jupyter-lsp/jupyterlab-lsp/pull/711#issuecomment-981161263

I cannot reproduce it locally.