### PR TITLE
Prepare jupyterlab-lsp 3.9.2 and jupyter-lsp 1.5.1 release

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -26,7 +26,7 @@ env:
 
   # Increase this value to reset all caches
   CACHE_EPOCH: 4
-  JULIA_LANGSERVER: 3.2.0
+  JULIA_LANGSERVER: 4.1.0
 
 jobs:
   lint:
@@ -330,9 +330,6 @@ jobs:
 
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
-        with:
-          # temporarily pin because of https://github.com/julia-vscode/SymbolServer.jl/issues/225
-          version: '1.6'
 
       - name: Install Julia language server
         run: julia -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="LanguageServer", version="${{ env.JULIA_LANGSERVER }}"))'

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -25,8 +25,8 @@ env:
   JLPM_CMD: jlpm --ignore-optional --prefer-offline --frozen-lockfile
 
   # Increase this value to reset all caches
-  CACHE_EPOCH: 2
-  JULIA_LANGSERVER: 3.2.0
+  CACHE_EPOCH: 3
+  JULIA_LANGSERVER: 4.1.0
 
 jobs:
   lint:
@@ -223,9 +223,8 @@ jobs:
             # Node 14 end-of-life: April 2023
             nodejs: '>=14,<15.0.0.a0'
           - python: 3.8
-            # TODO: switch to Node 16 once gets merged https://github.com/conda-forge/nodejs-feedstock/pull/189
-            # Node 15 end-of-life: June 2021
-            nodejs: '>=15,<16.0.0.a0'
+            # Node 16 end-of-life: April 2024
+            nodejs: '>=16,<17.0.0.a0'
           # TODO: remove when mambaforge just works on setup-miniconda
           - os: 'ubuntu-latest'
             mambaforge: Linux-x86_64.sh
@@ -343,6 +342,12 @@ jobs:
 
       - name: Run browser tests
         run: python scripts/atest.py --exclude expect:fail
+
+      - name: Find and remove empty files
+        # https://github.com/actions/upload-artifact/issues/150
+        run: find ./atest/output -empty -delete
+        if: always()
+        shell: bash
 
       - name: Publish browser test output
         uses: actions/upload-artifact@v2

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -25,8 +25,8 @@ env:
   JLPM_CMD: jlpm --ignore-optional --prefer-offline --frozen-lockfile
 
   # Increase this value to reset all caches
-  CACHE_EPOCH: 3
-  JULIA_LANGSERVER: 4.1.0
+  CACHE_EPOCH: 4
+  JULIA_LANGSERVER: 3.2.0
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 ## Changelog
 
+### `@krassowski/jupyterlab-lsp 3.9.2` (2021-12-11)
+
+- features:
+  - add `details-below` layout allowing to change the completer arrangement
+- bug fixes:
+  - prevent very long completion details text from extending the completer indefinitely ([#698])
+  - correct status translations ([#700], thanks @fcollonval)
+  - fix translations in status pop-up ([#703])
+  - workaround issue causing file rename when opening external files by jumping to them ([#712], thanks @jepcor97)
+  - fix sorting by "Line:Ch" and "Cell" in Diagnostics Panel ([#717])
+  - fix header border missing when scrolling in Diagnostics Panel ([#717])
+- documentation improvements:
+  - clarify that JupyterLab restart is needed after installation ([#714], thanks @3coins)
+
+[#698]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/698
+[#700]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/700
+[#703]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/703
+[#712]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/712
+[#714]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/714
+[#717]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/717
+
+### `jupyter-lsp 1.5.1` (2021-12-11)
+
+- documentation improvements:
+  - document troubleshooting steps for `texlab` server([#702])
+- maintenance and upkeep:
+  - migrate test configuration to `ServerApp` as needed ([#713])
+  - address deprecation warnings ([#713])
+
+[#702]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/702
+[#713]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/713
+
 ### `@krassowski/jupyterlab-lsp 3.9.1` (2021-10-24)
 
 - bug fixes:
@@ -11,7 +43,7 @@
 
 - features:
   - add support for new `typescript-language-server` replacing `javascript-typescript-langserver`;
-    despite the name both packages provide support for all four: JavaScrip, JSX, TypeScript and TSX;
+    despite the name both packages provide support for all four: JavaScript, JSX, TypeScript and TSX;
     the old `javascript-typescript-langserver` can still be used, but it is no longer maintained
     and we will not be supported, and specs may be removed in the next major release ([#697]).
 

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp-metapackage",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/jupyter-lsp/jupyterlab-lsp",
   "bugs": {

--- a/python_packages/jupyter_lsp/jupyter_lsp/_version.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/_version.py
@@ -1,3 +1,3 @@
 """ single source of truth for jupyter_lsp version
 """
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/conftest.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/conftest.py
@@ -97,8 +97,11 @@ def jsonrpc_init_msg():
             "method": "initialize",
             "params": {
                 "capabilities": {
+                    # see: https://github.com/julia-vscode/LanguageServer.jl/issues/1008
                     # LanguageServer.jl assumes that it is not missing
-                    "workspace": {"didChangeConfiguration": {}}
+                    "workspace": {"didChangeConfiguration": {}},
+                    # LanguageServer.jl assumes that it is not missing
+                    "textDocument": {}
                 },
                 "initializationOptions": None,
                 "processId": None,

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_listener.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_listener.py
@@ -91,7 +91,7 @@ async def test_listeners(known_server, handlers, jsonrpc_init_msg):
             all_listened.get(),
             return_exceptions=True,
         ),
-        120 if known_server == "julia-language-server" else 20,
+        240 if known_server == "julia-language-server" else 20,
     )
     assert all([isinstance(res, dict) for res in results])
 


### PR DESCRIPTION
- We don't have jupyter-releaser integration in just yet, but it is still acceptable to watch the progress of this PR's GitHub Action listening to The Final Countdown (https://github.com/jupyter-server/jupyter_releaser/issues/202).