### PR TITLE
Bump completion theme version, update release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## Changelog
 
-### `@krassowski/jupyterlab-lsp 3.9.2` (2021-12-11)
+### `@krassowski/jupyterlab-lsp 3.9.2` (2021-12-12)
 
-- features:
-  - add `details-below` layout allowing to change the completer arrangement
 - bug fixes:
   - prevent very long completion details text from extending the completer indefinitely ([#698])
   - correct status translations ([#700], thanks @fcollonval)
@@ -21,7 +19,12 @@
 [#714]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/714
 [#717]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/717
 
-### `jupyter-lsp 1.5.1` (2021-12-11)
+### `@krassowski/completion-theme 3.2.0` (2021-12-12)
+
+- features:
+  - add `details-below` layout allowing to change the completer arrangement ([#698])
+
+### `jupyter-lsp 1.5.1` (2021-12-12)
 
 - documentation improvements:
   - document troubleshooting steps for `texlab` server([#702])

--- a/packages/completion-theme/package.json
+++ b/packages/completion-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/completion-theme",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Completion theme manager for JupyterLab-LSP",
   "keywords": [
     "jupyter",

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@krassowski/code-jumpers": "~1.1.0",
-    "@krassowski/completion-theme": "~3.1.0",
+    "@krassowski/completion-theme": "~3.2.0",
     "@krassowski/theme-material": "~2.1.1",
     "@krassowski/theme-vscode": "~2.1.1",
     "lodash.mergewith": "^4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,7 +2067,7 @@
   version "1.1.0"
 
 "@krassowski/completion-theme@file:packages/completion-theme":
-  version "3.1.0"
+  version "3.2.0"
 
 "@krassowski/jupyterlab-lsp-example-extractor@file:packages/_example-extractor":
   version "0.0.0"
@@ -2083,7 +2083,7 @@
   version "3.9.2"
   dependencies:
     "@krassowski/code-jumpers" "~1.1.0"
-    "@krassowski/completion-theme" "~3.1.0"
+    "@krassowski/completion-theme" "~3.2.0"
     "@krassowski/theme-material" "~2.1.1"
     "@krassowski/theme-vscode" "~2.1.1"
     lodash.mergewith "^4.6.1"


### PR DESCRIPTION
Follow up after #719 because #698 introduced a change in `completion-theme` package, so we cannot release 3.9.2 with that feature without bumping `completion-theme` first.