### PR TITLE
Add Robot Framework language server (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Changelog
 
+### `jupyter-lsp 1.6.0` (unreleased)
+
+- compatibility:
+  - raises the minimum supported Python to 3.7 as 3.6 reaches its end-of-life ([#723])
+- maintenance and upkeep:
+  - adds Python 3.10, PyPy 3.7, and R 4.x to the automated tests ([#723])
+
+[#768]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/723
+
 ### `@krassowski/jupyterlab-lsp 3.9.2` (2021-12-12)
 
 - bug fixes:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -33,3 +33,8 @@ dependencies:
   - tectonic
   - texlab
   - chktex
+  # robotframework
+  - jupyterlab_robotmode
+  - robotframework-lsp
+  - robotframework-robocop
+  - robotkernel

--- a/docs/rtd.yml
+++ b/docs/rtd.yml
@@ -16,6 +16,7 @@ dependencies:
   - python >=3.7,<3.11.0a0
   - python-graphviz
   - python-lsp-server
+  - robotframework-lsp
   - sphinx
   - sphinx-autodoc-typehints
   - sphinx-book-theme

--- a/requirements/atest.txt
+++ b/requirements/atest.txt
@@ -2,4 +2,7 @@
 -r ./lab.txt
 bs4
 robotframework >=4
+robotframework-lsp
+robotframework-pabot
 robotframework-seleniumlibrary
+robotkernel

--- a/requirements/atest.yml
+++ b/requirements/atest.yml
@@ -5,7 +5,10 @@ channels:
   - nodefaults
 
 dependencies:
-  - robotframework-seleniumlibrary
-  - robotframework >=4
   - firefox
   - geckodriver
+  - jupyterlab_robotmode
+  - robotframework >=4
+  - robotframework-pabot
+  - robotframework-seleniumlibrary
+  - robotkernel

--- a/requirements/github-actions.yml
+++ b/requirements/github-actions.yml
@@ -10,9 +10,15 @@ dependencies:
   - pip
   - nodejs {nodejs}
   # for python language server (and development)
+  - python-lsp-server
   - flake8 >=3.5
-  # temporarily pin autopep8
   - autopep8 <1.6.0
+  # robotframework for testing and language server
+  - jupyterlab_robotmode
+  - robotframework >=4
+  - robotframework-lsp
+  - robotframework-robocop
+  - robotkernel
   # for R language server and kernel
   - r {r}
   - r-irkernel
@@ -34,6 +40,5 @@ dependencies:
   - bs4
   - firefox
   - geckodriver
-  - robotframework >=4
+  - robotframework-pabot
   - robotframework-seleniumlibrary
-  - python-lsp-server

--- a/requirements/lint.yml
+++ b/requirements/lint.yml
@@ -5,11 +5,11 @@ channels:
   - nodefaults
 
 dependencies:
-  - pip
   - black
   - isort
   - mypy
-  - robotframework-lint >=1.1
-  - robotframework >=4,<4.1
+  - pip
   - pytest-tornasync
+  - robotframework-lint
+  - robotframework-robocop
   - types-six


### PR DESCRIPTION
## References

- fixes #332
- supersedes #493

## Code changes

- refreshes robot dependencies
- adds new robot stuff
  - robotkernel
  - robotframework-lsp
  - robotframework-robocop (not configured yet)
  - robotframework-pabot (interested to see the intersection of this with other tools)
  - jupyterlab-robotmode

## User-facing changes

- vistors to the binder will see more robot-related features

## Backwards-incompatible changes

- n/a

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry 