### PR TITLE
Squash warnings and errors in web console

### DIFF
--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -722,7 +722,11 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
 
   abstract context_from_active_document(): ICommandContext | null;
 
-  get_context(root_position: IRootPosition): ICommandContext {
+  get_context(root_position: IRootPosition): ICommandContext | null {
+    // ignore premature calls and calls after disposal
+    if (!this.virtual_editor) {
+      return null;
+    }
     let document = this.virtual_editor.document_at_root_position(root_position);
     let virtual_position =
       this.virtual_editor.root_position_to_virtual_position(root_position);
@@ -738,7 +742,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     };
   }
 
-  get_context_from_context_menu(): ICommandContext {
+  get_context_from_context_menu(): ICommandContext | null {
     let root_position = this.get_position_from_context_menu();
     return this.get_context(root_position);
   }

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -620,7 +620,8 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
     connection: LSPConnection,
     response: lsProtocol.PublishDiagnosticsParams
   ) => {
-    if (!uris_equal(response.uri, this.virtual_document.document_info.uri)) {
+    // use optional chaining operator because the diagnostics message may come late (after the document was disposed)
+    if (!uris_equal(response.uri, this.virtual_document?.document_info?.uri)) {
       return;
     }
 

--- a/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
@@ -537,7 +537,9 @@ export class CodeMirrorVirtualEditor
   forEveryBlockEditor(
     callback: (cm_editor: CodeMirror.Editor) => any,
     monitor_for_new_blocks = true,
-    on_editor_removed_callback: (cm_editor: CodeMirror.Editor) => any = null
+    on_editor_removed_callback: (
+      cm_editor: CodeMirror.Editor
+    ) => any | null = null
   ) {
     const editors_with_handlers = new Set<CodeMirror.Editor>();
 
@@ -568,6 +570,9 @@ export class CodeMirrorVirtualEditor
         adapter: WidgetAdapter<IDocumentWidget>,
         data: IEditorChangedData
       ) => {
+        if (on_editor_removed_callback == null) {
+          return;
+        }
         let { editor } = data;
         if (editor == null) {
           return;


### PR DESCRIPTION
## References

As highlighted in few issues, squashes some warnings:
- `TypeError: Cannot read properties of null (reading 'uri')` - this warrants a further investigation, looks like we have a regression and do dispose some connections properly so diagnostics keep coming; still this highlights a logic 
- `LSP: is_visible failed TypeError: Cannot read properties of undefined (reading 'virtual_line')` - context is sometimes requested when the document is not open yet, or already closed, we should handle it
- `TypeError: n is not a function` - this was an error in handling of a default arguments.

TODO:
- [ ] let's try to enable `strictNullChecks` #130 - this will add a lot of optional chaining but should force us to think about the values being possibly disposed due to the asynchronous nature the communication.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [ ] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
