### PR TITLE
Enable strict null checks and other strict settings

### DIFF
--- a/packages/_example-extractor/src/api.spec.ts
+++ b/packages/_example-extractor/src/api.spec.ts
@@ -37,7 +37,7 @@ describe('The foo extractor', () => {
   test.each(Object.entries(FIXTURES))(
     '%s',
     (_: string, expected: IExtractedCode) => {
-      const extracted = extractor.extract_foreign_code(expected.host_code);
+      const extracted = extractor.extract_foreign_code(expected.host_code!);
       expect(extracted).to.have.length(1);
       expect(extracted[0]).to.deep.equal(expected);
     }

--- a/packages/code-jumpers/src/history.ts
+++ b/packages/code-jumpers/src/history.ts
@@ -30,7 +30,7 @@ export class JumpHistory {
     this.jump_history.push(JSON.stringify(position));
   }
 
-  recollect(): IGlobalPosition {
+  recollect(): IGlobalPosition | undefined {
     this.ensure_history_is_ready();
     if (this.jump_history.length === 0) {
       return;

--- a/packages/code-jumpers/src/jumpers/fileeditor.ts
+++ b/packages/code-jumpers/src/jumpers/fileeditor.ts
@@ -36,7 +36,7 @@ export class FileEditorJumper extends CodeJumper {
 
     // TODO: this is common
     // place cursor in the line with the definition
-    let position = this.editor.editor.getPositionAt(token.offset);
+    let position = this.editor.editor.getPositionAt(token.offset)!;
     this.editor.editor.setSelection({ start: position, end: position });
     this.editor.editor.focus();
   }
@@ -58,7 +58,7 @@ export class FileEditorJumper extends CodeJumper {
   getCurrentPosition(): IGlobalPosition {
     let position = this.editor.editor.getCursorPosition();
     return {
-      editor_index: null,
+      editor_index: 0,
       line: position.line,
       column: position.column,
       contents_path: this.editor.context.path,

--- a/packages/code-jumpers/src/jumpers/jumper.ts
+++ b/packages/code-jumpers/src/jumpers/jumper.ts
@@ -69,12 +69,16 @@ export abstract class CodeJumper {
     let document_widget = this.document_manager.openOrReveal(
       position.contents_path
     );
+    if (!document_widget) {
+      console.log('Widget failed to open for jump');
+      return;
+    }
     let is_symlink = position.is_symlink;
 
     document_widget.revealed
       .then(() => {
         this.go_to_position(
-          document_widget,
+          document_widget!,
           position.contents_path.endsWith('.ipynb') ? 'notebook' : 'fileeditor',
           position.column,
           position.line,
@@ -83,7 +87,7 @@ export abstract class CodeJumper {
 
         // protect external files from accidental edition
         if (is_symlink) {
-          this.protectFromAccidentalEditing(document_widget);
+          this.protectFromAccidentalEditing(document_widget!);
         }
       })
       .catch(console.warn);

--- a/packages/code-jumpers/src/jumpers/notebook.ts
+++ b/packages/code-jumpers/src/jumpers/notebook.ts
@@ -19,7 +19,7 @@ export class NotebookJumper extends CodeJumper {
     super();
     this.widget = notebook_widget;
     this.notebook = notebook_widget.content;
-    this.history = new JumpHistory(this.notebook.model.modelDB);
+    this.history = new JumpHistory(this.notebook.model!.modelDB);
     this.document_manager = document_manager;
   }
 
@@ -33,15 +33,15 @@ export class NotebookJumper extends CodeJumper {
     // Prevents event propagation issues
     setTimeout(() => {
       this.notebook.deselectAll();
-      this.notebook.activeCellIndex = index;
+      this.notebook.activeCellIndex = index!;
       _ensureFocus(this.notebook);
       this.notebook.mode = 'edit';
 
       // find out offset for the element
-      let activeEditor = this.notebook.activeCell.editor;
+      let activeEditor = this.notebook.activeCell!.editor;
 
       // place cursor in the line with the definition
-      let position = activeEditor.getPositionAt(token.offset);
+      let position = activeEditor.getPositionAt(token.offset)!;
       activeEditor.setSelection({ start: position, end: position });
     }, 0);
   }

--- a/packages/code-jumpers/src/positions.ts
+++ b/packages/code-jumpers/src/positions.ts
@@ -6,14 +6,15 @@ export interface ILocalPosition {
    */
   token: CodeEditor.IToken;
   /**
-   * Optional number identifying the cell in a notebook
+   * Optional number identifying the cell in a notebook.
+   * 0 in widgets with single editor
    */
-  index?: number;
+  index: number;
 }
 
 export interface IGlobalPosition {
   /**
-   * In notebooks, the index of the target editor
+   * In notebooks, the index of the target editor; 0 in widgets with single editor.
    */
   editor_index: number;
 

--- a/packages/completion-theme/src/about.tsx
+++ b/packages/completion-theme/src/about.tsx
@@ -69,7 +69,7 @@ export function render_themes_list(
   trans: TranslationBundle,
   props: {
     themes: ICompletionTheme[];
-    current: ICompletionTheme;
+    current: ICompletionTheme | null;
     get_set: IconSetGetter;
   }
 ): React.ReactElement {

--- a/packages/completion-theme/src/index.ts
+++ b/packages/completion-theme/src/index.ts
@@ -23,7 +23,7 @@ import {
 export class CompletionThemeManager implements ILSPCompletionThemeManager {
   protected current_icons: Map<string, LabIcon>;
   protected themes: Map<string, ICompletionTheme>;
-  private current_theme_id: string;
+  private current_theme_id: string | null = null;
   private icons_cache: Map<string, LabIcon>;
   private icon_overrides: Map<string, CompletionItemKindStrings>;
   private trans: TranslationBundle;
@@ -50,17 +50,17 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
     const dark_mode_and_dark_supported =
       !this.is_theme_light() && typeof icons_sets.dark !== 'undefined';
     const set: ICompletionIconSet = dark_mode_and_dark_supported
-      ? icons_sets.dark
+      ? icons_sets.dark!
       : icons_sets.light;
     const icons: Map<keyof ICompletionIconSet, LabIcon> = new Map();
-    let options = this.current_theme.icons.options || {};
+    let options = this.current_theme?.icons?.options || {};
     const mode = this.is_theme_light() ? 'light' : 'dark';
     for (let [completion_kind, svg] of Object.entries(set)) {
       let name =
         'lsp:' + theme.id + '-' + completion_kind.toLowerCase() + '-' + mode;
       let icon: LabIcon;
       if (this.icons_cache.has(name)) {
-        icon = this.icons_cache.get(name);
+        icon = this.icons_cache.get(name)!;
       } else {
         icon = new LabIcon({
           name: name,
@@ -83,19 +83,19 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
     this.current_icons = this.get_iconset(this.current_theme);
   }
 
-  get_icon(type: string): LabIcon {
+  get_icon(type: string): LabIcon | null {
     if (this.current_theme === null) {
       return null;
     }
     if (type) {
       if (this.icon_overrides.has(type.toLowerCase())) {
-        type = this.icon_overrides.get(type.toLowerCase());
+        type = this.icon_overrides.get(type.toLowerCase())!;
       }
       type =
         type.substring(0, 1).toUpperCase() + type.substring(1).toLowerCase();
     }
     if (this.current_icons.has(type)) {
-      return this.current_icons.get(type);
+      return this.current_icons.get(type)!;
     }
 
     if (type === KernelKind) {
@@ -112,7 +112,7 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
     if (this.current_theme_id) {
       document.body.classList.remove(this.current_theme_class);
     }
-    if (!this.themes.has(id)) {
+    if (id && !this.themes.has(id)) {
       console.warn(
         `[LSP][Completer] Icons theme ${id} cannot be set yet (it may be loaded later).`
       );
@@ -123,8 +123,8 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
   }
 
   protected get current_theme(): ICompletionTheme | null {
-    if (this.themes.has(this.current_theme_id)) {
-      return this.themes.get(this.current_theme_id);
+    if (this.current_theme_id && this.themes.has(this.current_theme_id)) {
+      return this.themes.get(this.current_theme_id)!;
     }
     return null;
   }

--- a/packages/jupyterlab-lsp/src/adapter_manager.ts
+++ b/packages/jupyterlab-lsp/src/adapter_manager.ts
@@ -132,9 +132,9 @@ export class WidgetAdapterManager implements ILSPAdapterManager {
     this.refreshAdapterFromCurrentWidget();
   }
 
-  isAnyActive() {
+  isAnyActive(): boolean {
     return (
-      this.shell.currentWidget &&
+      this.shell.currentWidget !== null &&
       this.adapterTypes.some(type => type.tracker.currentWidget) &&
       this.adapterTypes.some(
         type => type.tracker.currentWidget == this.shell.currentWidget

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -647,6 +647,8 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
         connection,
         virtual_document
       };
+    } else {
+      return undefined;
     }
   }
 

--- a/packages/jupyterlab-lsp/src/adapters/file_editor/file_editor.ts
+++ b/packages/jupyterlab-lsp/src/adapters/file_editor/file_editor.ts
@@ -37,9 +37,8 @@ export class FileEditorAdapter extends WidgetAdapter<
       // registry (and this is arguably easier to extend), so let's check it
       // just in case; this is also how the "Klingon" language for testing
       // gets registered, so we need it for tests too.
-      let fileType = this.extension.app.docRegistry.getFileTypeForModel(
-        this.editor.context.contentsModel
-      );
+      let fileType =
+        this.extension.app.docRegistry.getFileTypeForModel(contentsModel);
       return fileType.mimeTypes[0];
     } else {
       // "text/plain" this is
@@ -105,11 +104,15 @@ export class FileEditorAdapter extends WidgetAdapter<
     return this.widget.context.path;
   }
 
-  context_from_active_document(): ICommandContext {
+  context_from_active_document(): ICommandContext | null {
+    // short circuit if disposed
+    if (!this.virtual_editor || !this.get_context) {
+      return null;
+    }
     let editor = this.widget.content.editor;
     let ce_cursor = editor.getCursorPosition();
     let root_position = PositionConverter.ce_to_cm(ce_cursor) as IRootPosition;
-    return this?.get_context(root_position);
+    return this.get_context(root_position);
   }
 
   get_editor_index_at(position: IVirtualPosition): number {

--- a/packages/jupyterlab-lsp/src/command_manager.spec.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.spec.ts
@@ -14,12 +14,12 @@ describe('ContextMenuCommandManager', () => {
   class ManagerImplementation extends ContextCommandManager {
     constructor(options: IContextMenuOptions) {
       super({
-        app: null,
-        adapter_manager: null,
-        palette: null,
-        tracker: null,
-        suffix: null,
-        entry_point: null,
+        app: null as any,
+        adapter_manager: null as any,
+        palette: null as any,
+        tracker: null as any,
+        suffix: null as any,
+        entry_point: null as any,
         console: new BrowserConsole(),
         ...options
       });
@@ -33,7 +33,7 @@ describe('ContextMenuCommandManager', () => {
     selector: string;
 
     get current_adapter(): WidgetAdapter<IDocumentWidget> {
-      return undefined;
+      return undefined as any;
     }
   }
   let manager: ManagerImplementation;
@@ -52,7 +52,7 @@ describe('ContextMenuCommandManager', () => {
   describe('#get_rank()', () => {
     it('uses in-group (relative) positioning by default', () => {
       manager = new ManagerImplementation({
-        selector: null,
+        selector: 'body',
         rank_group: 0,
         rank_group_size: 5
       });
@@ -63,7 +63,7 @@ describe('ContextMenuCommandManager', () => {
       expect(rank).to.equal(1 / 5);
 
       manager = new ManagerImplementation({
-        selector: null,
+        selector: 'body',
         rank_group: 1,
         rank_group_size: 5
       });
@@ -72,7 +72,7 @@ describe('ContextMenuCommandManager', () => {
       expect(rank).to.equal(1 + 1 / 5);
 
       manager = new ManagerImplementation({
-        selector: null
+        selector: 'body'
       });
       rank = manager.get_rank(base_command);
       expect(rank).to.equal(Infinity);
@@ -81,7 +81,7 @@ describe('ContextMenuCommandManager', () => {
 
   it('respects is_rank_relative value', () => {
     manager = new ManagerImplementation({
-      selector: null,
+      selector: 'body',
       rank_group: 0,
       rank_group_size: 5
     });

--- a/packages/jupyterlab-lsp/src/command_manager.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.ts
@@ -138,7 +138,7 @@ export class ContextCommandManager extends LSPCommandManager {
     this.app.contextMenu.addItem({
       type: 'separator',
       selector: this.selector,
-      rank: this.rank_group + position_in_group
+      rank: (this.rank_group ?? 0) + position_in_group
     });
   }
 
@@ -171,7 +171,7 @@ export class ContextCommandManager extends LSPCommandManager {
   }
 
   get_context(): ICommandContext | null {
-    let context: ICommandContext = null;
+    let context: ICommandContext | null = null;
     if (this.is_context_menu_open) {
       try {
         context = this.current_adapter.get_context_from_context_menu();
@@ -195,7 +195,8 @@ export class ContextCommandManager extends LSPCommandManager {
       return (
         context != null &&
         this.current_adapter &&
-        context.connection?.isReady &&
+        context.connection != null &&
+        context.connection.isReady &&
         command.is_enabled(context)
       );
     } catch (e) {
@@ -225,7 +226,7 @@ export class ContextCommandManager extends LSPCommandManager {
 export interface ICommandContext {
   app: JupyterFrontEnd;
   document: VirtualDocument;
-  connection: LSPConnection;
+  connection?: LSPConnection;
   virtual_position: IVirtualPosition;
   root_position: IRootPosition;
   features: Map<string, IFeatureEditorIntegration<any>>;

--- a/packages/jupyterlab-lsp/src/command_manager.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.ts
@@ -6,7 +6,7 @@ import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { WidgetAdapter } from './adapters/adapter';
 import { LSPConnection } from './connection';
 import { IFeatureCommand, IFeatureEditorIntegration } from './feature';
-import { IRootPosition, IVirtualPosition } from './positioning';
+import { IRootPosition, IVirtualPosition, PositionError } from './positioning';
 import { ILSPAdapterManager, ILSPLogConsole } from './tokens';
 import { VirtualDocument } from './virtual/document';
 import { IVirtualEditor } from './virtual/editor';
@@ -184,7 +184,17 @@ export class ContextCommandManager extends LSPCommandManager {
       }
     }
     if (context == null) {
-      context = this.current_adapter?.context_from_active_document();
+      try {
+        context = this.current_adapter?.context_from_active_document();
+      } catch (e) {
+        if (e instanceof PositionError) {
+          this.console.log(
+            'Could not get context from active document: it is expected when restoring workspace with open files'
+          );
+        } else {
+          throw e;
+        }
+      }
     }
     return context;
   }

--- a/packages/jupyterlab-lsp/src/components/free_tooltip.ts
+++ b/packages/jupyterlab-lsp/src/components/free_tooltip.ts
@@ -107,7 +107,7 @@ export class FreeTooltip extends Tooltip {
       return;
     }
 
-    let position: CodeEditor.IPosition;
+    let position: CodeEditor.IPosition | undefined;
 
     switch (this.options.alignment) {
       case 'start': {
@@ -165,7 +165,7 @@ export namespace EditorTooltip {
 }
 
 export class EditorTooltipManager {
-  private currentTooltip: FreeTooltip = null;
+  private currentTooltip: FreeTooltip | null = null;
   private currentOptions: EditorTooltip.IOptions | null;
 
   constructor(private rendermime_registry: IRenderMimeRegistry) {}
@@ -175,7 +175,7 @@ export class EditorTooltipManager {
     this.currentOptions = options;
     let { markup, position, adapter } = options;
     let widget = adapter.widget;
-    const bundle =
+    const bundle: { 'text/plain': string } | { 'text/markdown': string } =
       markup.kind === 'plaintext'
         ? { 'text/plain': markup.value }
         : { 'text/markdown': markup.value };
@@ -188,14 +188,16 @@ export class EditorTooltipManager {
       position: PositionConverter.cm_to_ce(position)
     });
     tooltip.addClass(CLASS_NAME);
-    tooltip.addClass(options.className);
+    if (options.className) {
+      tooltip.addClass(options.className);
+    }
     Widget.attach(tooltip, document.body);
     this.currentTooltip = tooltip;
     return tooltip;
   }
 
   get position(): IEditorPosition {
-    return this.currentOptions.position;
+    return this.currentOptions!.position;
   }
 
   isShown(id?: string): boolean {
@@ -203,7 +205,7 @@ export class EditorTooltipManager {
       return false;
     }
     return (
-      this.currentTooltip &&
+      this.currentTooltip !== null &&
       !this.currentTooltip.isDisposed &&
       this.currentTooltip.isVisible
     );
@@ -212,7 +214,7 @@ export class EditorTooltipManager {
   remove() {
     if (this.currentTooltip !== null) {
       this.currentTooltip.dispose();
-      this.currentTooltip = null;
+      this.currentTooltip = null as any;
     }
   }
 }

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -54,7 +54,7 @@ interface IServerStatusProps {
 }
 
 function ServerStatus(props: IServerStatusProps) {
-  let list = props.server.spec.languages.map((language, i) => (
+  let list = props.server.spec.languages!.map((language, i) => (
     <li key={i}>{language}</li>
   ));
   return (
@@ -290,7 +290,7 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
             <li key={i}>
               <DocumentLocator
                 document={document}
-                adapter={this.model.adapter}
+                adapter={this.model.adapter!}
               />
               <span className={'lsp-document-status'}>
                 {this.model.trans.__(status)}
@@ -399,7 +399,7 @@ const SELECTED_CLASS = 'jp-mod-selected';
  * StatusBar item.
  */
 export class LSPStatus extends VDomRenderer<LSPStatus.Model> {
-  protected _popup: Popup = null;
+  protected _popup: Popup | null = null;
   private interactiveStateObserver: MutationObserver;
   private trans: TranslationBundle;
   /**
@@ -471,7 +471,9 @@ export class LSPStatus extends VDomRenderer<LSPStatus.Model> {
             className={'lsp-status-message'}
             source={model.short_message}
           />
-        ) : null}
+        ) : (
+          <></>
+        )}
         <TextItem source={model.feature_message} />
       </GroupItem>
     );
@@ -597,7 +599,7 @@ export namespace LSPStatus {
    * A VDomModel for the LSP of current file editor/notebook.
    */
   export class Model extends VDomModel {
-    server_extension_status: SCHEMA.ServersResponse = null;
+    server_extension_status: SCHEMA.ServersResponse | null = null;
     language_server_manager: ILanguageServerManager;
     trans: TranslationBundle;
     private _connection_manager: DocumentConnectionManager;
@@ -625,7 +627,7 @@ export namespace LSPStatus {
     get supported_languages(): Set<string> {
       const languages = new Set<string>();
       for (let server of this.available_servers.values()) {
-        for (let language of server.spec.languages) {
+        for (let language of server.spec.languages!) {
           languages.add(language.toLocaleLowerCase());
         }
       }
@@ -646,6 +648,7 @@ export namespace LSPStatus {
           return true;
         }
       }
+      return false;
     }
 
     get documents_by_server(): Map<
@@ -673,19 +676,19 @@ export namespace LSPStatus {
           continue;
         }
         // For now only use the server with the highest priority
-        let server = this.language_server_manager.sessions.get(server_ids[0]);
+        let server = this.language_server_manager.sessions.get(server_ids[0])!;
 
         if (!data.has(server)) {
           data.set(server, new Map<string, VirtualDocument[]>());
         }
 
-        let documents_map = data.get(server);
+        let documents_map = data.get(server)!;
 
         if (!documents_map.has(language)) {
           documents_map.set(language, new Array<VirtualDocument>());
         }
 
-        let documents = documents_map.get(language);
+        let documents = documents_map.get(language)!;
         documents.push(document);
       }
       return data;

--- a/packages/jupyterlab-lsp/src/components/utils.tsx
+++ b/packages/jupyterlab-lsp/src/components/utils.tsx
@@ -19,6 +19,7 @@ export function getBreadcrumbs(
       let path = document.path;
       if (
         !document.has_lsp_supported_file &&
+        document.file_extension &&
         path.endsWith(document.file_extension)
       ) {
         path = path.slice(0, -document.file_extension.length - 1);
@@ -41,18 +42,18 @@ export function getBreadcrumbs(
     }
     try {
       if (adapter.has_multiple_editors) {
-        let first_line = document.virtual_lines.get(0);
+        let first_line = document.virtual_lines.get(0)!;
         let last_line = document.virtual_lines.get(
           document.last_virtual_line - 1
-        );
+        )!;
 
         let first_cell = adapter.get_editor_index(first_line.editor);
         let last_cell = adapter.get_editor_index(last_line.editor);
 
         let cell_locator =
           first_cell === last_cell
-            ? trans.__('cell %1', first_cell + 1)
-            : trans.__('cells: %1-%2', first_cell + 1, last_cell + 1);
+            ? trans!.__('cell %1', first_cell + 1)
+            : trans!.__('cells: %1-%2', first_cell + 1, last_cell + 1);
 
         return (
           <span key={document.uri}>
@@ -75,7 +76,7 @@ export function get_breadcrumbs(
   adapter: WidgetAdapter<IDocumentWidget>,
   collapse = true
 ) {
-  return getBreadcrumbs(document, adapter, null, collapse);
+  return getBreadcrumbs(document, adapter, undefined, collapse);
 }
 
 export function focus_on(node: HTMLElement) {
@@ -92,7 +93,7 @@ export function DocumentLocator(props: {
   trans?: TranslationBundle;
 }) {
   let { document, adapter } = props;
-  let target: HTMLElement = null;
+  let target: HTMLElement | null = null;
   if (adapter.has_multiple_editors) {
     let first_line = document.virtual_lines.get(0);
     if (first_line) {
@@ -105,7 +106,7 @@ export function DocumentLocator(props: {
   return (
     <div
       className={'lsp-document-locator'}
-      onClick={() => focus_on(target ? target : null)}
+      onClick={() => (target ? focus_on(target) : null)}
     >
       {breadcrumbs}
     </div>

--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -150,7 +150,7 @@ export class DocumentConnectionManager {
     // of connecting.
     const connection = await Private.connection(
       language,
-      language_server_id,
+      language_server_id!,
       uris,
       this.on_new_connection,
       this.console
@@ -191,9 +191,11 @@ export class DocumentConnectionManager {
       if (!allServerSettings.hasOwnProperty(language_server_id)) {
         continue;
       }
-      const rawSettings = allServerSettings[language_server_id];
+      const rawSettings = allServerSettings[language_server_id]!;
 
-      const parsedSettings = expandDottedPaths(rawSettings.serverSettings);
+      const parsedSettings = expandDottedPaths(
+        rawSettings.serverSettings || {}
+      );
 
       const serverSettings: protocol.DidChangeConfigurationParams = {
         settings: parsedSettings
@@ -267,7 +269,7 @@ export class DocumentConnectionManager {
       if (connection !== a_connection) {
         continue;
       }
-      callback(this.documents.get(virtual_document_uri));
+      callback(this.documents.get(virtual_document_uri)!);
     }
   }
 
@@ -496,7 +498,7 @@ namespace Private {
       onCreate(connection);
     }
 
-    connection = _connections.get(language_server_id);
+    connection = _connections.get(language_server_id)!;
 
     return connection;
   }

--- a/packages/jupyterlab-lsp/src/editor_integration/cm_adapter.spec.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/cm_adapter.spec.ts
@@ -17,7 +17,7 @@ describe('CodeMirrorAdapter', () => {
     it('updates on change', async () => {
       class UpdateReceivingFeature extends CodeMirrorIntegration {
         public received_update = false;
-        public last_change: CodeMirror.EditorChange = null;
+        public last_change: CodeMirror.EditorChange = null as any;
         public last_change_position: IRootPosition;
 
         afterChange(change: IEditorChange, root_position: IRootPosition): void {

--- a/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
@@ -104,7 +104,7 @@ export abstract class CodeMirrorIntegration
 
   protected trans: TranslationBundle;
 
-  get settings(): IFeatureSettings<any> {
+  get settings(): IFeatureSettings<any> | undefined {
     return this.feature.settings;
   }
 
@@ -176,12 +176,12 @@ export abstract class CodeMirrorIntegration
         this.transform_virtual_position_to_root_position(start);
       let ce_editor =
         this.virtual_editor.get_editor_at_root_position(start_in_root);
-      cm_editor = this.virtual_editor.ce_editor_to_cm_editor.get(ce_editor);
+      cm_editor = this.virtual_editor.ce_editor_to_cm_editor.get(ce_editor)!;
     }
 
     return {
-      start: this.virtual_document.transform_virtual_to_editor(start),
-      end: this.virtual_document.transform_virtual_to_editor(end),
+      start: this.virtual_document.transform_virtual_to_editor(start)!,
+      end: this.virtual_document.transform_virtual_to_editor(end)!,
       editor: cm_editor
     };
   }
@@ -199,13 +199,13 @@ export abstract class CodeMirrorIntegration
   public transform_virtual_position_to_root_position(
     start: IVirtualPosition
   ): IRootPosition {
-    let ce_editor = this.virtual_document.virtual_lines.get(start.line).editor;
+    let ce_editor = this.virtual_document.virtual_lines.get(start.line)!.editor;
     let editor_position =
       this.virtual_document.transform_virtual_to_editor(start);
     return this.virtual_editor.transform_from_editor_to_root(
       ce_editor,
-      editor_position
-    );
+      editor_position!
+    )!;
   }
 
   protected get_cm_editor(position: IRootPosition) {
@@ -261,10 +261,10 @@ export abstract class CodeMirrorIntegration
       ? workspaceEdit.documentChanges.map(
           change => change as lsProtocol.TextDocumentEdit
         )
-      : toDocumentChanges(workspaceEdit.changes);
+      : toDocumentChanges(workspaceEdit.changes!);
     let applied_changes = 0;
-    let edited_cells: number;
-    let is_whole_document_edit: boolean;
+    let edited_cells: number = 0;
+    let is_whole_document_edit: boolean = false;
     let errors: string[] = [];
 
     for (let change of changes) {
@@ -310,7 +310,7 @@ export abstract class CodeMirrorIntegration
           // going over the edits in descending order of start points:
           let start_offsets = [...edits_by_offset.keys()].sort((a, b) => a - b);
           for (let start of start_offsets) {
-            let edit = edits_by_offset.get(start);
+            let edit = edits_by_offset.get(start)!;
             let prefix = value.slice(last_end, start);
             for (let i = 0; i < prefix.split('\n').length; i++) {
               let new_lines = old_to_new_line.get_or_create(current_old_line);
@@ -379,7 +379,7 @@ export abstract class CodeMirrorIntegration
       newFragmentText = newFragmentText.slice(0, -1);
     }
 
-    let doc = this.virtual_editor.ce_editor_to_cm_editor.get(editor).getDoc();
+    let doc = this.virtual_editor.ce_editor_to_cm_editor.get(editor)!.getDoc();
 
     let raw_value = doc.getValue('\n');
     // extract foreign documents and substitute magics,

--- a/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
@@ -186,14 +186,19 @@ export abstract class CodeMirrorIntegration
     };
   }
 
-  protected position_from_mouse(event: MouseEvent): IRootPosition {
-    return this.virtual_editor.coordsChar(
+  protected position_from_mouse(event: MouseEvent): IRootPosition | null {
+    const position = this.virtual_editor.coordsChar(
       {
         left: event.clientX,
         top: event.clientY
       },
       'window'
-    ) as IRootPosition;
+    );
+    if (position.line === -1 && position.ch === -1) {
+      return null;
+    } else {
+      return position as IRootPosition;
+    }
   }
 
   public transform_virtual_position_to_root_position(

--- a/packages/jupyterlab-lsp/src/editor_integration/editor_adapter.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/editor_adapter.ts
@@ -88,6 +88,7 @@ export class EditorAdapter<T extends IVirtualEditor<IEditor>> {
       this.console.error(e);
     }
     this.invalidateLastChange();
+    return undefined;
   }
 
   public invalidateLastChange() {

--- a/packages/jupyterlab-lsp/src/editor_integration/editor_adapter.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/editor_adapter.ts
@@ -13,7 +13,7 @@ export class EditorAdapter<T extends IVirtualEditor<IEditor>> {
   features: Map<string, IFeatureEditorIntegration<T>>;
   isDisposed = false;
 
-  private last_change: IEditorChange;
+  private last_change: IEditorChange | null;
   private console: ILSPLogConsole;
 
   constructor(
@@ -50,7 +50,7 @@ export class EditorAdapter<T extends IVirtualEditor<IEditor>> {
       return;
     }
 
-    let change: IEditorChange = this.last_change;
+    let change: IEditorChange | null = this.last_change;
 
     let root_position: IRootPosition;
 
@@ -75,7 +75,9 @@ export class EditorAdapter<T extends IVirtualEditor<IEditor>> {
 
       for (let feature of this.features.values()) {
         try {
-          feature.afterChange(change, root_position);
+          if (feature.afterChange) {
+            feature.afterChange(change, root_position);
+          }
         } catch (err) {
           console.warn('afterChange of feature', feature, 'failed with', err);
         }
@@ -107,7 +109,7 @@ export class EditorAdapter<T extends IVirtualEditor<IEditor>> {
     this.editor.change.disconnect(this.saveChange);
 
     // just to be sure
-    this.editor = null;
+    this.editor = null as any;
 
     // actually disposed
     this.isDisposed = true;

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -90,8 +90,8 @@ export class MockSettings<T> implements IFeatureSettings<T> {
     this.changed = new Signal(this);
   }
 
-  get composite(): T {
-    return this.settings;
+  get composite(): Required<T> {
+    return this.settings as Required<T>;
   }
 
   set(setting: keyof T, value: any): void {
@@ -112,7 +112,7 @@ export class MockExtension implements ILSPExtension {
   translator: ITranslator;
 
   constructor() {
-    this.app = null;
+    this.app = null as any;
     this.feature_manager = new FeatureManager();
     this.editor_type_manager = new VirtualEditorManager();
     this.language_server_manager = new MockLanguageServerManager({
@@ -130,7 +130,7 @@ export class MockExtension implements ILSPExtension {
     this.foreign_code_extractors = {};
     this.code_overrides = {};
     this.console = new BrowserConsole();
-    this.user_console = null;
+    this.user_console = null as any;
   }
 }
 
@@ -247,7 +247,7 @@ function FeatureSupport<TBase extends TestEnvironmentConstructor>(Base: TBase) {
     }
 
     public dispose_feature(feature: CodeMirrorIntegration) {
-      let connection = this._connections.get(feature);
+      let connection = this._connections.get(feature)!;
       connection.close();
       feature.is_registered = false;
     }
@@ -410,16 +410,16 @@ export const python_notebook_metadata = {
 export function showAllCells(notebook: Notebook) {
   notebook.show();
   // iterate over every cell to activate the editors
-  for (let i = 0; i < notebook.model.cells.length; i++) {
+  for (let i = 0; i < notebook.model!.cells.length; i++) {
     notebook.activeCellIndex = i;
-    notebook.activeCell.show();
+    notebook.activeCell!.show();
   }
 }
 
 export function getCellsJSON(notebook: Notebook): Array<nbformat.ICell> {
   let cells: Array<ICellModel> = [];
-  for (let i = 0; i < notebook.model.cells.length; i++) {
-    cells.push(notebook.model.cells.get(i));
+  for (let i = 0; i < notebook.model!.cells.length; i++) {
+    cells.push(notebook.model!.cells.get(i));
   }
   return cells.map(cell => cell.toJSON());
 }

--- a/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
+++ b/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
@@ -112,10 +112,10 @@ describe('RegExpForeignCodeExtractor', () => {
       expect(result.host_code).to.equal(PYTHON_CELL_MAGIC_WITH_H);
       expect(result.foreign_code).to.equal('h');
 
-      expect(result.range.start.line).to.equal(1);
-      expect(result.range.start.column).to.equal(0);
-      expect(result.range.end.line).to.equal(1);
-      expect(result.range.end.column).to.equal(1);
+      expect(result.range!.start.line).to.equal(1);
+      expect(result.range!.start.column).to.equal(0);
+      expect(result.range!.end.line).to.equal(1);
+      expect(result.range!.end.column).to.equal(1);
     });
 
     it('should work with non-line magic and non-cell magic code snippets as well', () => {
@@ -138,10 +138,10 @@ describe('RegExpForeignCodeExtractor', () => {
       expect(result.foreign_code).to.equal(
         '<a href="#">\n<b>important</b> link\n</a>'
       );
-      expect(result.range.start.line).to.equal(1);
-      expect(result.range.start.column).to.equal(7);
-      expect(result.range.end.line).to.equal(3);
-      expect(result.range.end.column).to.equal(4);
+      expect(result.range!.start.line).to.equal(1);
+      expect(result.range!.start.column).to.equal(7);
+      expect(result.range!.end.line).to.equal(3);
+      expect(result.range!.end.column).to.equal(4);
       let last_bit = results[1];
       expect(last_bit.host_code).to.equal('""";\nprint(x)');
     });
@@ -153,8 +153,8 @@ describe('RegExpForeignCodeExtractor', () => {
 
       expect(result.host_code).to.equal(R_CELL_MAGIC_EXISTS);
       expect(result.foreign_code).to.equal('some text\n');
-      expect(result.range.start.line).to.equal(1);
-      expect(result.range.start.column).to.equal(0);
+      expect(result.range!.start.line).to.equal(1);
+      expect(result.range!.start.column).to.equal(0);
     });
 
     it('should extract and remove from host', () => {
@@ -215,8 +215,8 @@ describe('RegExpForeignCodeExtractor', () => {
 
       expect(first_magic.foreign_code).to.equal('df = data.frame()');
       expect(first_magic.host_code).to.equal('%R df = data.frame()\n');
-      expect(first_magic.range.end.line).to.equal(0);
-      expect(first_magic.range.end.column).to.equal(20);
+      expect(first_magic.range!.end.line).to.equal(0);
+      expect(first_magic.range!.end.column).to.equal(20);
 
       let second_magic = results[1];
 

--- a/packages/jupyterlab-lsp/src/extractors/testutils.ts
+++ b/packages/jupyterlab-lsp/src/extractors/testutils.ts
@@ -5,7 +5,7 @@ import { IVirtualDocumentBlock, VirtualDocument } from '../virtual/document';
 
 export function extract_code(document: VirtualDocument, code: string) {
   return document.extract_foreign_code(
-    { value: code, ce_editor: null },
+    { value: code, ce_editor: null as any },
     {
       line: 0,
       column: 0
@@ -24,7 +24,7 @@ export function get_the_only_pair(
   expect(foreign_document_map.size).to.equal(1);
 
   let range = foreign_document_map.keys().next().value;
-  let { virtual_document } = foreign_document_map.get(range);
+  let { virtual_document } = foreign_document_map.get(range)!;
 
   return { range, virtual_document };
 }

--- a/packages/jupyterlab-lsp/src/extractors/types.ts
+++ b/packages/jupyterlab-lsp/src/extractors/types.ts
@@ -9,8 +9,9 @@ export interface IExtractedCode {
   foreign_code: string | null;
   /**
    * Range of the foreign code relative to the original source.
+   * `null` is used internally to represent a leftover host code after extraction.
    */
-  range: CodeEditor.IRange;
+  range: CodeEditor.IRange | null;
   /**
    * Shift due to any additional code inserted at the beginning of the virtual document
    * (usually in order to mock the arguments passed to a magic, or to provide other context clues for the linters)

--- a/packages/jupyterlab-lsp/src/feature.ts
+++ b/packages/jupyterlab-lsp/src/feature.ts
@@ -54,7 +54,7 @@ export interface IFeatureCommand {
 }
 
 export interface IFeatureSettings<T> {
-  readonly composite: T;
+  readonly composite: Required<T>;
   readonly changed: Signal<IFeatureSettings<T>, void>;
   readonly ready?: Promise<void>;
 
@@ -90,8 +90,8 @@ export class FeatureSettings<T> implements IFeatureSettings<T> {
     }
   }
 
-  get composite(): T {
-    return this.settings.composite as unknown as T;
+  get composite(): Required<T> {
+    return this.settings.composite as unknown as Required<T>;
   }
 
   set(setting: keyof T, value: any) {

--- a/packages/jupyterlab-lsp/src/features/completion/index.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/index.ts
@@ -9,6 +9,7 @@ import { LabIcon } from '@jupyterlab/ui-components';
 import { ILSPCompletionThemeManager } from '@krassowski/completion-theme/lib/types';
 
 import completionSvg from '../../../style/icons/completion.svg';
+import { CodeCompletion as LSPCompletionSettings } from '../../_completion';
 import { FeatureSettings } from '../../feature';
 import {
   ILSPAdapterManager,
@@ -52,7 +53,7 @@ export const COMPLETION_PLUGIN: JupyterFrontEndPlugin<void> = {
     const labIntegration = new CompletionLabIntegration(
       app,
       completionManager,
-      settings,
+      settings as FeatureSettings<LSPCompletionSettings>,
       adapterManager,
       iconsThemeManager,
       logConsole.scope('CompletionLab'),

--- a/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
@@ -11,7 +11,13 @@ describe('LSPCompleterModel', () => {
     match: lsProtocol.CompletionItem,
     type: string = 'dummy'
   ) {
-    return new LazyCompletionItem(type, null, match, null, null);
+    return new LazyCompletionItem(
+      type,
+      null as any,
+      match,
+      null as any,
+      'file://test.ipynb'
+    );
   }
 
   const jupyter_icon_completion = create_dummy_item({

--- a/packages/jupyterlab-lsp/src/features/completion/model.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.ts
@@ -39,7 +39,7 @@ export class GenericCompleterModel<
   completionItems(): T[] {
     let query = this.query;
     this.query = '';
-    let unfilteredItems = super.completionItems() as T[];
+    let unfilteredItems = super.completionItems!() as T[];
     this.query = query;
 
     // always want to sort
@@ -48,7 +48,7 @@ export class GenericCompleterModel<
   }
 
   setCompletionItems(newValue: T[]) {
-    super.setCompletionItems(newValue);
+    super.setCompletionItems!(newValue);
   }
 
   private _markFragment(value: string): string {
@@ -80,8 +80,8 @@ export class GenericCompleterModel<
 
       let matched: boolean;
 
-      let filterText: string = null;
-      let filterMatch: StringExt.IMatchResult;
+      let filterText: string | null = null;
+      let filterMatch: StringExt.IMatchResult | null = null;
 
       let lowerCaseQuery = query.toLowerCase();
 
@@ -108,7 +108,7 @@ export class GenericCompleterModel<
         // If the matches are substrings of label, highlight them
         // in this part of the label that can be highlighted (must be a prefix),
         // which is intended to avoid highlighting matches in function arguments etc.
-        let labelMatch: StringExt.IMatchResult;
+        let labelMatch: StringExt.IMatchResult | null = null;
         if (query) {
           let labelPrefix = escapeHTML(this.getHighlightableLabelRegion(item));
           if (labelPrefix == filterText) {

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
@@ -77,7 +77,7 @@ describe('Diagnostics', () => {
       markers = env.ce_editor.editor.getDoc().getAllMarks();
       expect(markers.length).to.equal(0);
 
-      feature.handleDiagnostic(null, {
+      feature.handleDiagnostic(null as any, {
         uri: env.document_options.path,
         diagnostics: diagnostics
       });
@@ -99,7 +99,7 @@ describe('Diagnostics', () => {
       env.ce_editor.model.value.text = text;
       await env.adapter.update_documents();
 
-      feature.handleDiagnostic(null, {
+      feature.handleDiagnostic(null as any, {
         uri: env.document_options.path,
         diagnostics: diagnostics
       });
@@ -124,7 +124,7 @@ describe('Diagnostics', () => {
       env.ce_editor.model.value.text = text;
       await env.adapter.update_documents();
 
-      feature.handleDiagnostic(null, {
+      feature.handleDiagnostic(null as any, {
         uri: env.document_options.path,
         diagnostics: diagnostics
       });
@@ -167,7 +167,7 @@ describe('Diagnostics', () => {
       let document = env.virtual_editor.virtual_document;
       let uri = env.virtual_editor.virtual_document.uri;
 
-      feature.handleDiagnostic(null, {
+      feature.handleDiagnostic(null as any, {
         uri: uri,
         diagnostics: [
           {
@@ -240,14 +240,14 @@ describe('Diagnostics', () => {
       expect(merged_mark_title).to.contain('\n');
 
       expect(feature.diagnostics_db.size).to.equal(1);
-      expect(feature.diagnostics_db.get(document).length).to.equal(5);
+      expect(feature.diagnostics_db.get(document)!.length).to.equal(5);
 
       feature.switchDiagnosticsPanelSource();
       diagnostics_panel.widget.content.update();
       // the panel should contain all 5 diagnostics
-      let db = diagnostics_panel.content.model.diagnostics;
+      let db = diagnostics_panel.content.model.diagnostics!;
       expect(db.size).to.equal(1);
-      expect(db.get(document).length).to.equal(5);
+      expect(db.get(document)!.length).to.equal(5);
     });
 
     it('Works in foreign documents', async () => {
@@ -285,7 +285,7 @@ describe('Diagnostics', () => {
       } as lsProtocol.PublishDiagnosticsParams;
 
       // test guards against wrongly propagated responses:
-      feature.handleDiagnostic(null, response);
+      feature.handleDiagnostic(null as any, response);
       let cm_editors = env.adapter.editors.map(
         ce_editor => (ce_editor as CodeMirrorEditor).editor
       );
@@ -297,7 +297,7 @@ describe('Diagnostics', () => {
       expect(marks_cell_2.length).to.equal(0);
 
       // correct propagation
-      foreign_feature.handleDiagnostic(null, response);
+      foreign_feature.handleDiagnostic(null as any, response);
 
       marks_cell_1 = cm_editors[0].getDoc().getAllMarks();
       marks_cell_2 = cm_editors[1].getDoc().getAllMarks();
@@ -307,14 +307,14 @@ describe('Diagnostics', () => {
 
       let mark = marks_cell_2[0] as TextMarker<MarkerRange>;
 
-      let mark_position = mark.find();
+      let mark_position = mark.find()!;
 
       // second line (0th and 1st virtual lines) + 1 line for '%%python\n' => line: 2
       expect(is_equal(mark_position.from, { line: 2, ch: 0 })).to.be.true;
       expect(is_equal(mark_position.to, { line: 2, ch: 1 })).to.be.true;
 
       // the silenced diagnostic for the %%python magic should be ignored
-      feature.handleDiagnostic(null, {
+      feature.handleDiagnostic(null as any, {
         uri: document.uri,
         diagnostics: [
           {

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -106,6 +106,7 @@ class DiagnosticsPanel {
           return column;
         }
       }
+      return undefined;
     };
 
     /** Columns Menu **/

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -50,8 +50,8 @@ function escapeRegExp(string: string) {
 }
 
 class DiagnosticsPanel {
-  private _content: DiagnosticsListing = null;
-  private _widget: MainAreaWidget<DiagnosticsListing> = null;
+  private _content: DiagnosticsListing | null = null;
+  private _widget: MainAreaWidget<DiagnosticsListing> | null = null;
   feature: DiagnosticsCM;
   is_registered = false;
   trans: TranslationBundle;
@@ -114,14 +114,14 @@ class DiagnosticsPanel {
 
     app.commands.addCommand(CMD_COLUMN_VISIBILITY, {
       execute: args => {
-        let column = get_column(args['id'] as string);
+        let column = get_column(args['id'] as string)!;
         column.is_visible = !column.is_visible;
         widget.update();
       },
       label: args => this.trans.__(args['id'] as string),
       isToggled: args => {
         let column = get_column(args['id'] as string);
-        return column.is_visible;
+        return column ? column.is_visible : false;
       }
     });
 
@@ -143,14 +143,14 @@ class DiagnosticsPanel {
       'Ignore diagnostics like this'
     );
 
-    let get_row = (): IDiagnosticsRow => {
+    let get_row = (): IDiagnosticsRow | undefined => {
       let tr = app.contextMenuHitTest(
         node => node.tagName.toLowerCase() == 'tr'
       );
       if (!tr) {
         return;
       }
-      return this.widget.content.get_diagnostic(tr.dataset.key);
+      return this.widget.content.get_diagnostic(tr.dataset.key!);
     };
 
     ignore_diagnostics_menu.addItem({
@@ -161,7 +161,14 @@ class DiagnosticsPanel {
     });
     app.commands.addCommand(CMD_IGNORE_DIAGNOSTIC_CODE, {
       execute: () => {
-        const diagnostic = get_row().data.diagnostic;
+        const row = get_row();
+        if (!row) {
+          console.warn(
+            'LPS: diagnostics row not found for ignore code execute()'
+          );
+          return;
+        }
+        const diagnostic = row.data.diagnostic;
         let current = this.content.model.settings.composite.ignoreCodes;
         this.content.model.settings.set('ignoreCodes', [
           ...current,
@@ -192,6 +199,12 @@ class DiagnosticsPanel {
     app.commands.addCommand(CMD_IGNORE_DIAGNOSTIC_MSG, {
       execute: () => {
         const row = get_row();
+        if (!row) {
+          console.warn(
+            'LPS: diagnostics row not found for ignore message execute()'
+          );
+          return;
+        }
         const diagnostic = row.data.diagnostic;
         let current =
           this.content.model.settings.composite.ignoreMessagesPatterns;
@@ -225,6 +238,10 @@ class DiagnosticsPanel {
     app.commands.addCommand(CMD_JUMP_TO_DIAGNOSTIC, {
       execute: () => {
         const row = get_row();
+        if (!row) {
+          console.warn('LPS: diagnostics row not found for jump execute()');
+          return;
+        }
         this.widget.content.jump_to(row);
       },
       label: this.trans.__('Jump to location'),
@@ -235,6 +252,7 @@ class DiagnosticsPanel {
       execute: () => {
         const row = get_row();
         if (!row) {
+          console.warn('LPS: diagnostics row not found for copy execute()');
           return;
         }
         const message = row.data.diagnostic.message;
@@ -335,7 +353,7 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
     if (!diagnostics_databases.has(this.virtual_editor)) {
       diagnostics_databases.set(this.virtual_editor, new DiagnosticsDatabase());
     }
-    return diagnostics_databases.get(this.virtual_editor);
+    return diagnostics_databases.get(this.virtual_editor)!;
   }
 
   switchDiagnosticsPanelSource = () => {
@@ -385,7 +403,7 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
       let range_id = get_range_id(range);
       range_id_to_range.set(range_id, range);
       if (range_id_to_diagnostics.has(range_id)) {
-        let ranges_list = range_id_to_diagnostics.get(range_id);
+        let ranges_list = range_id_to_diagnostics.get(range_id)!;
         ranges_list.push(diagnostic);
       } else {
         range_id_to_diagnostics.set(range_id, [diagnostic]);
@@ -396,7 +414,7 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
 
     range_id_to_diagnostics.forEach(
       (range_diagnostics: lsProtocol.Diagnostic[], range_id: RangeID) => {
-        let range = range_id_to_range.get(range_id);
+        let range = range_id_to_range.get(range_id)!;
         map.set(range, range_diagnostics);
       }
     );
@@ -517,7 +535,7 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
 
         if (
           document.virtual_lines
-            .get(start.line)
+            .get(start.line)!
             .skip_inspect.indexOf(document.id_path) !== -1
         ) {
           this.console.log(
@@ -535,10 +553,18 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
 
         let ce_editor = document.get_editor_at_virtual_line(start);
         let cm_editor =
-          this.virtual_editor.ce_editor_to_cm_editor.get(ce_editor);
+          this.virtual_editor.ce_editor_to_cm_editor.get(ce_editor)!;
 
         let start_in_editor = document.transform_virtual_to_editor(start);
-        let end_in_editor: IEditorPosition;
+        let end_in_editor: IEditorPosition | null;
+
+        if (start_in_editor === null) {
+          this.console.warn(
+            'Start in editor could not be be determined for',
+            diagnostics
+          );
+          return;
+        }
 
         // some servers return strange positions for ends
         try {
@@ -546,6 +572,14 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
         } catch (err) {
           this.console.warn('Malformed range for diagnostic', end);
           end_in_editor = { ...start_in_editor, ch: start_in_editor.ch + 1 };
+        }
+
+        if (end_in_editor === null) {
+          this.console.warn(
+            'End in editor could not be be determined for',
+            diagnostics
+          );
+          return;
         }
 
         let range_in_editor = {

--- a/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
@@ -40,7 +40,7 @@ export class DiagnosticsDatabase extends Map<
   IEditorDiagnostic[]
 > {
   get all(): Array<IEditorDiagnostic> {
-    return [].concat.apply([], this.values());
+    return [].concat.apply([], this.values() as any);
   }
 }
 
@@ -316,7 +316,10 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
         });
       }
     );
-    let flattened: IDiagnosticsRow[] = [].concat.apply([], by_document);
+    let flattened: IDiagnosticsRow[] = ([] as IDiagnosticsRow[]).concat.apply(
+      [],
+      by_document
+    );
     this._diagnostics = new Map(flattened.map(row => [row.key, row]));
 
     let sorted_column = this.columns.filter(

--- a/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
@@ -33,6 +33,7 @@ export interface IEditorDiagnostic {
 }
 
 export const DIAGNOSTICS_LISTING_CLASS = 'lsp-diagnostics-listing';
+const DIAGNOSTICS_PLACEHOLDER_CLASS = 'lsp-diagnostics-placeholder';
 
 export class DiagnosticsDatabase extends Map<
   VirtualDocument,
@@ -119,7 +120,7 @@ function SortableTH(props: {
     <th
       key={props.id}
       onClick={() => props.listing.sort(props.id)}
-      className={is_sort_key ? 'lsp-sorted-header' : null}
+      className={is_sort_key ? 'lsp-sorted-header' : undefined}
       data-id={props.id}
     >
       <div>
@@ -212,22 +213,40 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
             <td key={3}>{this.severityTranslations[severity] || severity}</td>
           );
         },
-        sort: (a, b) =>
-          a.data.diagnostic.severity > b.data.diagnostic.severity ? 1 : -1
+        sort: (a, b) => {
+          if (!a.data.diagnostic.severity) {
+            return +1;
+          }
+          if (!b.data.diagnostic.severity) {
+            return -1;
+          }
+          return a.data.diagnostic.severity > b.data.diagnostic.severity
+            ? 1
+            : -1;
+        }
       }),
       new Column({
         id: 'Source',
         label: this.trans.__('Source'),
         render_cell: row => <td key={4}>{row.data.diagnostic.source}</td>,
-        sort: (a, b) =>
-          a.data.diagnostic.source.localeCompare(b.data.diagnostic.source)
+        sort: (a, b) => {
+          if (!a.data.diagnostic.source) {
+            return +1;
+          }
+          if (!b.data.diagnostic.source) {
+            return -1;
+          }
+          return a.data.diagnostic.source.localeCompare(
+            b.data.diagnostic.source
+          );
+        }
       }),
       new Column({
         id: 'Cell',
         label: this.trans.__('Cell'),
         render_cell: row => <td key={5}>{row.cell_number}</td>,
         sort: (a, b) =>
-          a.cell_number - b.cell_number ||
+          a.cell_number! - b.cell_number! ||
           a.data.range.start.line - b.data.range.start.line ||
           a.data.range.start.ch - b.data.range.start.ch,
         is_available: context => context.adapter.has_multiple_editors
@@ -261,8 +280,19 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     let diagnostics_db = this.model.diagnostics;
     const editor = this.model.virtual_editor;
     const adapter = this.model.adapter;
-    if (!diagnostics_db || editor == null) {
-      return <div>{this.trans.__('No issues detected, great job!')}</div>;
+    if (diagnostics_db == null || editor == null || !adapter) {
+      return (
+        <div className={DIAGNOSTICS_PLACEHOLDER_CLASS}>
+          {this.trans.__('Diagnostics are not available')}
+        </div>
+      );
+    }
+    if (diagnostics_db.size === 0) {
+      return (
+        <div className={DIAGNOSTICS_PLACEHOLDER_CLASS}>
+          {this.trans.__('No issues detected, great job!')}
+        </div>
+      );
     }
 
     let by_document = Array.from(diagnostics_db).map(
@@ -271,7 +301,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
           return [];
         }
         return diagnostics.map((diagnostic_data, i) => {
-          let cell_number: number = null;
+          let cell_number: number | null = null;
           if (adapter.has_multiple_editors) {
             let { index: cell_id } = editor.find_editor(diagnostic_data.editor);
             cell_number = cell_id + 1;
@@ -337,7 +367,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     );
   }
 
-  get_diagnostic(key: string): IDiagnosticsRow {
+  get_diagnostic(key: string): IDiagnosticsRow | undefined {
     if (!this._diagnostics.has(key)) {
       console.warn('Could not find the diagnostics row with key', key);
       return;
@@ -358,9 +388,9 @@ export namespace DiagnosticsListing {
    * A VDomModel for the LSP of current file editor/notebook.
    */
   export class Model extends VDomModel {
-    diagnostics: DiagnosticsDatabase;
-    virtual_editor: CodeMirrorVirtualEditor;
-    adapter: WidgetAdapter<any>;
+    diagnostics: DiagnosticsDatabase | null;
+    virtual_editor: CodeMirrorVirtualEditor | null;
+    adapter: WidgetAdapter<any> | null;
     settings: FeatureSettings<LSPDiagnosticsSettings>;
     status_message: StatusMessage;
     trans: TranslationBundle;

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -494,6 +494,7 @@ export class HoverCM extends CodeMirrorIntegration {
       ) {
         this.console.warn(e);
       }
+      return undefined;
     }
   };
 

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -416,7 +416,7 @@ export class HoverCM extends CodeMirrorIntegration {
     }
 
     if (
-      this.last_hover_character &&
+      !this.last_hover_character ||
       !is_equal(root_position, this.last_hover_character)
     ) {
       let virtual_position =

--- a/packages/jupyterlab-lsp/src/features/jump_to.ts
+++ b/packages/jupyterlab-lsp/src/features/jump_to.ts
@@ -62,19 +62,20 @@ export class CMJumpToDefinition extends CodeMirrorIntegration {
     this.editor_handlers.set(
       'mousedown',
       (virtual_editor, event: MouseEvent) => {
-        let root_position = this.position_from_mouse(event);
-        if (root_position == null) {
-          this.console.warn(
-            'Could not retrieve root position from mouse event to jump to definition'
-          );
-          return;
-        }
-        let document = virtual_editor.document_at_root_position(root_position);
-        let virtual_position =
-          virtual_editor.root_position_to_virtual_position(root_position);
-
         const { button } = event;
         if (button === 0 && getModifierState(event, this.modifierKey)) {
+          let root_position = this.position_from_mouse(event);
+          if (root_position == null) {
+            this.console.warn(
+              'Could not retrieve root position from mouse event to jump to definition'
+            );
+            return;
+          }
+          let document =
+            virtual_editor.document_at_root_position(root_position);
+          let virtual_position =
+            virtual_editor.root_position_to_virtual_position(root_position);
+
           this.connection
             .getDefinition(virtual_position, document.document_info, false)
             .then(targets => {

--- a/packages/jupyterlab-lsp/src/features/jump_to.ts
+++ b/packages/jupyterlab-lsp/src/features/jump_to.ts
@@ -63,6 +63,12 @@ export class CMJumpToDefinition extends CodeMirrorIntegration {
       'mousedown',
       (virtual_editor, event: MouseEvent) => {
         let root_position = this.position_from_mouse(event);
+        if (root_position == null) {
+          this.console.warn(
+            'Could not retrieve root position from mouse event to jump to definition'
+          );
+          return;
+        }
         let document = virtual_editor.document_at_root_position(root_position);
         let virtual_position =
           virtual_editor.root_position_to_virtual_position(root_position);

--- a/packages/jupyterlab-lsp/src/features/jump_to.ts
+++ b/packages/jupyterlab-lsp/src/features/jump_to.ts
@@ -94,7 +94,7 @@ export class CMJumpToDefinition extends CodeMirrorIntegration {
 
   get_uri_and_range(location_or_locations: AnyLocation) {
     if (location_or_locations == null) {
-      return;
+      return undefined;
     }
     // some language servers appear to return a single object
     const locations = Array.isArray(location_or_locations)
@@ -105,7 +105,7 @@ export class CMJumpToDefinition extends CodeMirrorIntegration {
     //  (like when there are multiple definitions or usages)
     //  could use the showHints() or completion frontend as a reference
     if (locations.length === 0) {
-      return;
+      return undefined;
     }
 
     this.console.log(
@@ -125,6 +125,12 @@ export class CMJumpToDefinition extends CodeMirrorIntegration {
         uri: location_or_link.uri,
         range: location_or_link.range
       };
+    } else {
+      this.console.warn(
+        'Returned jump location is incorrect (no uri or targetUri):',
+        location_or_link
+      );
+      return undefined;
     }
   }
 

--- a/packages/jupyterlab-lsp/src/features/jump_to.ts
+++ b/packages/jupyterlab-lsp/src/features/jump_to.ts
@@ -140,6 +140,13 @@ export class CMJumpToDefinition extends CodeMirrorIntegration {
       // if in current file, transform from the position within virtual document to the editor position:
       let editor_position =
         this.virtual_editor.transform_virtual_to_editor(virtual_position);
+      if (editor_position === null) {
+        this.console.warn(
+          'Could not jump: conversion from virtual position to editor position failed',
+          virtual_position
+        );
+        return;
+      }
       let editor_position_ce = PositionConverter.cm_to_ce(editor_position);
       this.console.log(`Jumping to ${editor_index}th editor of ${uri}`);
       this.console.log('Jump target within editor:', editor_position_ce);
@@ -174,6 +181,11 @@ export class CMJumpToDefinition extends CodeMirrorIntegration {
 
       if (contents_path == null && uri.startsWith('file://')) {
         contents_path = decodeURI(uri.slice(7));
+      }
+
+      if (contents_path === null) {
+        this.console.warn('contents_path could not be resolved');
+        return;
       }
 
       try {
@@ -238,7 +250,7 @@ class JumperLabIntegration implements IFeatureLabIntegration {
 
   get jumper(): CodeJumper {
     let current = this.adapterManager.currentAdapter.widget.id;
-    return this.jumpers.get(current);
+    return this.jumpers.get(current)!;
   }
 }
 
@@ -247,14 +259,15 @@ const COMMANDS = (trans: TranslationBundle): IFeatureCommand[] => [
     id: 'jump-to-definition',
     execute: async ({ connection, virtual_position, document, features }) => {
       const jump_feature = features.get(FEATURE_ID) as CMJumpToDefinition;
-      const targets = await connection.getDefinition(
+      const targets = await connection?.getDefinition(
         virtual_position,
         document.document_info,
         false
       );
       await jump_feature.handle_jump(targets, document.document_info.uri);
     },
-    is_enabled: ({ connection }) => connection.isDefinitionSupported(),
+    is_enabled: ({ connection }) =>
+      connection ? connection.isDefinitionSupported() : false,
     label: trans.__('Jump to definition'),
     icon: jumpToIcon
   },
@@ -264,7 +277,8 @@ const COMMANDS = (trans: TranslationBundle): IFeatureCommand[] => [
       const jump_feature = features.get(FEATURE_ID) as CMJumpToDefinition;
       jump_feature.jumper.global_jump_back();
     },
-    is_enabled: ({ connection }) => connection.isDefinitionSupported(),
+    is_enabled: ({ connection }) =>
+      connection ? connection.isDefinitionSupported() : false,
     label: trans.__('Jump back'),
     icon: jumpBackIcon,
     // do not attach to any of the context menus

--- a/packages/jupyterlab-lsp/src/features/signature.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.spec.ts
@@ -10,7 +10,7 @@ describe('Signature', () => {
       const split = extractLead(
         ['This function does foo', '', 'But there are more details'],
         1
-      );
+      )!;
       expect(split.lead).to.equal('This function does foo');
       expect(split.remainder).to.equal('But there are more details');
     });
@@ -36,7 +36,7 @@ describe('Signature', () => {
           'But there are more details'
         ],
         2
-      );
+      )!;
       expect(split.lead).to.equal('This function does foo,\nand it does bar');
       expect(split.remainder).to.equal('But there are more details');
     });
@@ -66,7 +66,7 @@ describe('Signature', () => {
           parameters: [
             {
               label: 'text',
-              documentation: null
+              documentation: undefined
             }
           ],
           activeParameter: 0
@@ -91,7 +91,7 @@ describe('Signature', () => {
           parameters: [
             {
               label: 'text',
-              documentation: null
+              documentation: undefined
             }
           ],
           activeParameter: 0
@@ -116,7 +116,7 @@ describe('Signature', () => {
           parameters: [
             {
               label: 'text',
-              documentation: null
+              documentation: undefined
             }
           ],
           activeParameter: 0

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -68,7 +68,7 @@ export function extractLead(lines: string[], size: number): ISplit | null {
  */
 export function signatureToMarkdown(
   item: lsProtocol.SignatureInformation,
-  language: string,
+  language: string = '',
   codeHighlighter: (
     source: string,
     variable: string,
@@ -78,7 +78,7 @@ export function signatureToMarkdown(
   activeParameterFallback?: number | null,
   maxLinesBeforeCollapse: number = 4
 ): string {
-  const activeParameter: number | null =
+  const activeParameter: number | undefined | null =
     typeof item.activeParameter !== 'undefined'
       ? item.activeParameter
       : activeParameterFallback;
@@ -135,7 +135,7 @@ export function signatureToMarkdown(
       '\n\n' +
       item.parameters
         .filter(parameter => parameter.documentation)
-        .map(parameter => '- ' + getMarkdown(parameter.documentation))
+        .map(parameter => '- ' + getMarkdown(parameter.documentation!))
         .join('\n');
   }
   if (details) {
@@ -207,7 +207,7 @@ export class SignatureCM extends CodeMirrorIntegration {
     } else {
       // otherwise, update the signature as the active parameter could have changed,
       // or the server may want us to close the tooltip
-      this.requestSignature(newRootPosition, previousPosition).catch(
+      this.requestSignature(newRootPosition, previousPosition)?.catch(
         this.console.warn
       );
     }
@@ -219,7 +219,7 @@ export class SignatureCM extends CodeMirrorIntegration {
 
   protected get_markup_for_signature_help(
     response: lsProtocol.SignatureHelp,
-    language: string
+    language: string = ''
   ): lsProtocol.MarkupContent {
     let signatures = new Array<string>();
 
@@ -403,7 +403,7 @@ export class SignatureCM extends CodeMirrorIntegration {
       return;
     }
 
-    this.requestSignature(root_position, previousPosition).catch(
+    this.requestSignature(root_position, previousPosition)?.catch(
       this.console.warn
     );
   }
@@ -473,7 +473,10 @@ export const SIGNATURE_PLUGIN: JupyterFrontEndPlugin<void> = {
     renderMimeRegistry: IRenderMimeRegistry,
     codeMirror: ICodeMirror
   ) => {
-    const settings = new FeatureSettings(settingRegistry, FEATURE_ID);
+    const settings = new FeatureSettings<LSPSignatureSettings>(
+      settingRegistry,
+      FEATURE_ID
+    );
     const labIntegration = new SignatureLabIntegration(
       app,
       settings,

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -123,10 +123,7 @@ export function signatureToMarkdown(
       }
     } else {
       if (item.documentation.kind !== 'markdown') {
-        this.console.warn(
-          'Unknown MarkupContent kind:',
-          item.documentation.kind
-        );
+        console.warn('Unknown MarkupContent kind:', item.documentation.kind);
       }
       details += item.documentation.value;
     }

--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -104,7 +104,9 @@ export class FeatureManager implements ILSPFeatureManager {
       }
       this.command_manager_registered.connect(
         (feature_manager, command_manager) => {
-          command_manager.add(options.feature.commands);
+          if (options.feature.commands) {
+            command_manager.add(options.feature.commands);
+          }
         }
       );
     }
@@ -114,7 +116,7 @@ export class FeatureManager implements ILSPFeatureManager {
     if (options.feature.settings && options.feature.settings.ready) {
       options.feature.settings.ready
         .then(() => {
-          if (!options.feature.settings.composite.disable) {
+          if (!options.feature?.settings?.composite.disable) {
             this._register(options);
           } else {
             console.log('Skipping ', options.feature.id, 'as disabled');
@@ -163,7 +165,7 @@ export class LSPExtension implements ILSPExtension {
     private code_overrides_manager: ILSPCodeOverridesManager,
     public console: ILSPLogConsole,
     public translator: ITranslator,
-    public user_console: ILoggerRegistry,
+    public user_console: ILoggerRegistry | null,
     status_bar: IStatusBar | null
   ) {
     const trans = (translator || nullTranslator).load('jupyterlab_lsp');
@@ -198,7 +200,7 @@ export class LSPExtension implements ILSPExtension {
     this.setting_registry
       .load(plugin.id)
       .then(settings => {
-        const options = settings.composite as LanguageServer;
+        const options = settings.composite as Required<LanguageServer>;
         // Store the initial server settings, to be sent asynchronously
         // when the servers are initialized.
         const initial_configuration = (options.language_servers ||
@@ -248,7 +250,7 @@ export class LSPExtension implements ILSPExtension {
   }
 
   private updateOptions(settings: ISettingRegistry.ISettings) {
-    const options = settings.composite as LanguageServer;
+    const options = settings.composite as Required<LanguageServer>;
 
     const languageServerSettings = (options.language_servers ||
       {}) as TLanguageServerConfigurations;

--- a/packages/jupyterlab-lsp/src/manager.ts
+++ b/packages/jupyterlab-lsp/src/manager.ts
@@ -34,7 +34,7 @@ export class LanguageServerManager implements ILanguageServerManager {
     this._baseUrl = options.baseUrl || PageConfig.getBaseUrl();
     this._retries = options.retries || 2;
     this._retriesInterval = options.retriesInterval || 10000;
-    this._statusCode = null;
+    this._statusCode = -1;
     this._configuration = {};
     this.console = options.console;
     this.fetchSessions().catch(console.warn);
@@ -87,9 +87,9 @@ export class LanguageServerManager implements ILanguageServerManager {
   ) {
     // most things speak language
     // if language is not known, it is guessed based on MIME type earlier
-    // so some language should be available by now (which can be not obvious, e.g. "plain" for txt documents)
-    const lowerCaseLanguage = options.language.toLocaleLowerCase();
-    return spec.languages.some(
+    // so some language should be available by now (which can be not so obvious, e.g. "plain" for txt documents)
+    const lowerCaseLanguage = options.language!.toLocaleLowerCase();
+    return spec.languages!.some(
       language => language.toLocaleLowerCase() == lowerCaseLanguage
     );
   }

--- a/packages/jupyterlab-lsp/src/overrides/maps.ts
+++ b/packages/jupyterlab-lsp/src/overrides/maps.ts
@@ -28,7 +28,11 @@ export class ReversibleOverridesMap extends OverridesMap {
   }
 
   get reverse(): OverridesMap {
-    return this.type(this.overrides.map(override => override.reverse));
+    return this.type(
+      this.overrides
+        .filter(override => override.reverse != null)
+        .map(override => override.reverse!)
+    );
   }
 
   type(overrides: ICodeOverride[]) {

--- a/packages/jupyterlab-lsp/src/positioning.ts
+++ b/packages/jupyterlab-lsp/src/positioning.ts
@@ -64,3 +64,7 @@ export function offset_at_position(
   }
   return offset;
 }
+
+export class PositionError extends Error {
+  // no-op
+}

--- a/packages/jupyterlab-lsp/src/tokens.ts
+++ b/packages/jupyterlab-lsp/src/tokens.ts
@@ -186,7 +186,7 @@ export interface ILSPVirtualEditorManager {
    */
   findBestImplementation(
     editors: CodeEditor.IEditor[]
-  ): IVirtualEditorType<any>;
+  ): IVirtualEditorType<any> | null;
 }
 
 /**

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.spec.ts
@@ -14,14 +14,14 @@ describe('rpy2 IPython overrides', () => {
       overrides.filter(override => override.scope == 'cell')
     );
     it('overrides cell magic', () => {
-      let override = cell_magics.override_for(R_CELL_MAGIC);
+      let override = cell_magics.override_for(R_CELL_MAGIC)!;
       expect(override).to.equal(
         'rpy2.ipython.rmagic.RMagics.R("""print(1)\n""", "")'
       );
       let reverse = cell_magics.reverse.override_for(override);
       expect(reverse).to.equal(R_CELL_MAGIC);
 
-      override = cell_magics.override_for('%%R -i x -o y\nsome\ncode');
+      override = cell_magics.override_for('%%R -i x -o y\nsome\ncode')!;
       expect(override).to.equal(
         'y = rpy2.ipython.rmagic.RMagics.R("""some\ncode""", "", x)'
       );
@@ -37,7 +37,7 @@ describe('rpy2 IPython overrides', () => {
 
     it('works with other Rdevice', () => {
       let line = '%Rdevice svg';
-      let override = line_magics.override_for(line);
+      let override = line_magics.override_for(line)!;
       expect(override).to.equal(
         'rpy2.ipython.rmagic.RMagics.Rdevice(" svg", "")'
       );
@@ -53,19 +53,19 @@ describe('rpy2 IPython overrides', () => {
 
     it('works with the short form arguments, inputs and outputs', () => {
       let line = '%R -i x';
-      let override = line_magics.override_for(line);
+      let override = line_magics.override_for(line)!;
       expect(override).to.equal('rpy2.ipython.rmagic.RMagics.R("", "", x)');
       let reverse = line_magics.reverse.override_for(override);
       expect(reverse).to.equal(line);
 
       line = '%R -o x';
-      override = line_magics.override_for(line);
+      override = line_magics.override_for(line)!;
       expect(override).to.equal('x = rpy2.ipython.rmagic.RMagics.R("", "")');
       reverse = line_magics.reverse.override_for(override);
       expect(reverse).to.equal(line);
 
       line = '%R -i x command()';
-      override = line_magics.override_for(line);
+      override = line_magics.override_for(line)!;
       expect(override).to.equal(
         'rpy2.ipython.rmagic.RMagics.R(" command()", "", x)'
       );
@@ -73,7 +73,7 @@ describe('rpy2 IPython overrides', () => {
       expect(reverse).to.equal(line);
 
       line = '%R -i x -w 800 -h 400 command()';
-      override = line_magics.override_for(line);
+      override = line_magics.override_for(line)!;
       expect(override).to.equal(
         'rpy2.ipython.rmagic.RMagics.R(" command()", "-w 800 -h 400", x)'
       );
@@ -81,13 +81,13 @@ describe('rpy2 IPython overrides', () => {
       expect(reverse).to.equal(line);
 
       line = '%R -i x -o y -i z command()';
-      override = line_magics.override_for(line);
+      override = line_magics.override_for(line)!;
       expect(override).to.equal(
         'y = rpy2.ipython.rmagic.RMagics.R(" command()", "", x, z)'
       );
 
       line = '%R -i x -i z -o y -o w command()';
-      override = line_magics.override_for(line);
+      override = line_magics.override_for(line)!;
       expect(override).to.equal(
         'y, w = rpy2.ipython.rmagic.RMagics.R(" command()", "", x, z)'
       );
@@ -103,14 +103,14 @@ describe('rpy2 IPython overrides', () => {
 
     it('works with the long form arguments', () => {
       let line = '%R --input x';
-      let override = line_magics.override_for(line);
+      let override = line_magics.override_for(line)!;
       expect(override).to.equal('rpy2.ipython.rmagic.RMagics.R("", "", x)');
       let reverse = line_magics.reverse.override_for(override);
       // TODO: make this preserve the long form
       expect(reverse).to.equal('%R -i x');
 
       line = '%R --width 800 --height 400 command()';
-      override = line_magics.override_for(line);
+      override = line_magics.override_for(line)!;
       expect(override).to.equal(
         'rpy2.ipython.rmagic.RMagics.R(" command()", "--width 800 --height 400")'
       );

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
@@ -39,7 +39,7 @@ describe('Default IPython overrides', () => {
       overrides.filter(override => override.scope == 'cell')
     );
     it('overrides cell magics', () => {
-      let override = cell_magics_map.override_for(CELL_MAGIC_EXISTS);
+      let override = cell_magics_map.override_for(CELL_MAGIC_EXISTS)!;
       expect(override).to.equal(
         'get_ipython().run_cell_magic("MAGIC", "", """some text\n""")'
       );
@@ -51,7 +51,7 @@ describe('Default IPython overrides', () => {
     it('works for empty cells', () => {
       // those are not correct syntax, but will happen when users are in the process of writing
       const cell_magic_with_args = '%%MAGIC\n';
-      let override = cell_magics_map.override_for(cell_magic_with_args);
+      let override = cell_magics_map.override_for(cell_magic_with_args)!;
       expect(override).to.equal(
         'get_ipython().run_cell_magic("MAGIC", "", """""")'
       );
@@ -62,7 +62,7 @@ describe('Default IPython overrides', () => {
 
     it('escapes arguments in the first line', () => {
       const cell_magic_with_args = '%%MAGIC "arg in quotes"\ntext';
-      let override = cell_magics_map.override_for(cell_magic_with_args);
+      let override = cell_magics_map.override_for(cell_magic_with_args)!;
       expect(override).to.equal(
         'get_ipython().run_cell_magic("MAGIC", " \\"arg in quotes\\"", """text""")'
       );
@@ -72,7 +72,7 @@ describe('Default IPython overrides', () => {
     });
 
     it('escapes docstrings properly', () => {
-      let override = cell_magics_map.override_for(CELL_MAGIC_WITH_DOCSTRINGS);
+      let override = cell_magics_map.override_for(CELL_MAGIC_WITH_DOCSTRINGS)!;
       expect(override).to.equal(
         'get_ipython().run_cell_magic("MAGIC", "", """' +
           ESCAPED_TEXT_WITH_DOCSTRINGS +
@@ -97,7 +97,7 @@ describe('Default IPython overrides', () => {
       overrides.filter(override => override.scope == 'line')
     );
     it('overrides line magics', () => {
-      let override = line_magics_map.override_for(LINE_MAGIC_WITH_SPACE);
+      let override = line_magics_map.override_for(LINE_MAGIC_WITH_SPACE)!;
       expect(override).to.equal(
         'get_ipython().run_line_magic("MAGIC", " line = dd")'
       );
@@ -134,7 +134,7 @@ describe('Default IPython overrides', () => {
 
     it('escapes arguments', () => {
       let line_magic_with_args = '%MAGIC "arg"';
-      let override = line_magics_map.override_for(line_magic_with_args);
+      let override = line_magics_map.override_for(line_magic_with_args)!;
       expect(override).to.equal(
         'get_ipython().run_line_magic("MAGIC", " \\"arg\\"")'
       );
@@ -143,7 +143,7 @@ describe('Default IPython overrides', () => {
       expect(reverse).to.equal(line_magic_with_args);
 
       line_magic_with_args = '%MAGIC "arg\\"';
-      override = line_magics_map.override_for(line_magic_with_args);
+      override = line_magics_map.override_for(line_magic_with_args)!;
       expect(override).to.equal(
         'get_ipython().run_line_magic("MAGIC", " \\"arg\\\\\\"")'
       );
@@ -153,8 +153,8 @@ describe('Default IPython overrides', () => {
     });
 
     it('overrides shell commands', () => {
-      let override = line_magics_map.override_for('!ls -o');
-      expect(override).to.equal('get_ipython().getoutput("ls -o")');
+      let override = line_magics_map.override_for('!ls -o')!;
+      expect(override).to.equal('get_ipython().getoutput("ls -o")')!;
 
       let reverse = line_magics_map.reverse.override_for(override);
       expect(reverse).to.equal('!ls -o');
@@ -185,13 +185,13 @@ describe('Default IPython overrides', () => {
     );
 
     it('overrides pinfo', () => {
-      let override = line_magics_map.override_for('?int');
+      let override = line_magics_map.override_for('?int')!;
       expect(override).to.equal("get_ipython().run_line_magic('pinfo', 'int')");
 
       let reverse = line_magics_map.reverse.override_for(override);
       expect(reverse).to.equal('?int');
 
-      override = line_magics_map.override_for('int?');
+      override = line_magics_map.override_for('int?')!;
       expect(override).to.equal(
         "get_ipython().run_line_magic('pinfo',  'int')"
       );
@@ -201,7 +201,7 @@ describe('Default IPython overrides', () => {
     });
 
     it('overrides pinfo2', () => {
-      let override = line_magics_map.override_for('??int');
+      let override = line_magics_map.override_for('??int')!;
       expect(override).to.equal(
         "get_ipython().run_line_magic('pinfo2', 'int')"
       );
@@ -209,7 +209,7 @@ describe('Default IPython overrides', () => {
       let reverse = line_magics_map.reverse.override_for(override);
       expect(reverse).to.equal('??int');
 
-      override = line_magics_map.override_for('int??');
+      override = line_magics_map.override_for('int??')!;
       expect(override).to.equal(
         "get_ipython().run_line_magic('pinfo2',  'int')"
       );
@@ -217,7 +217,7 @@ describe('Default IPython overrides', () => {
       reverse = line_magics_map.reverse.override_for(override);
       expect(reverse).to.equal('int??');
 
-      override = line_magics_map.override_for('some_func??');
+      override = line_magics_map.override_for('some_func??')!;
       expect(override).to.equal(
         "get_ipython().run_line_magic('pinfo2',  'some_func')"
       );

--- a/packages/jupyterlab-lsp/src/utils.ts
+++ b/packages/jupyterlab-lsp/src/utils.ts
@@ -103,7 +103,7 @@ export class DefaultMap<K, V> extends Map<K, V> {
 
   get_or_create(k: K, ...args: any[]): V {
     if (this.has(k)) {
-      return super.get(k);
+      return super.get(k)!;
     } else {
       let v = this.default_factory(k, ...args);
       this.set(k, v);

--- a/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
@@ -407,6 +407,9 @@ export class CodeMirrorVirtualEditor
     }
   }
 
+  /**
+   * @note returns {line: -1, ch: -1} if position is outside of all editors
+   */
   coordsChar(
     object: { left: number; top: number },
     mode?: 'window' | 'page' | 'local'

--- a/packages/jupyterlab-lsp/src/virtual/console.ts
+++ b/packages/jupyterlab-lsp/src/virtual/console.ts
@@ -35,7 +35,7 @@ class FloatingConsole implements ILogConsoleImplementation {
   // likely to be replaced by JupyterLab console: https://github.com/jupyterlab/jupyterlab/pull/6833#issuecomment-543016425
   private readonly element: HTMLElement;
 
-  constructor(scope: string[] = ['LSP'], element: HTMLElement = null) {
+  constructor(scope: string[] = ['LSP'], element: HTMLElement | null = null) {
     if (element) {
       this.element = element;
     } else {
@@ -215,7 +215,7 @@ class ConsoleSingleton {
       this.implementation = new BrowserConsole();
     }
 
-    this.verbosity = composite.loggingLevel;
+    this.verbosity = composite.loggingLevel!;
     this.changed.emit();
   }
 }

--- a/packages/jupyterlab-lsp/src/virtual/document.spec.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.spec.ts
@@ -91,7 +91,7 @@ describe('VirtualDocument', () => {
     it('joins non-standalone fragments together', () => {
       let { cell_code_kept, foreign_document_map } =
         document.extract_foreign_code(
-          { value: R_LINE_MAGICS, ce_editor: null },
+          { value: R_LINE_MAGICS, ce_editor: null as any },
           {
             line: 0,
             column: 0
@@ -104,7 +104,7 @@ describe('VirtualDocument', () => {
 
       let { virtual_document: r_document } = foreign_document_map.get(
         foreign_document_map.keys().next().value
-      );
+      )!;
       expect(r_document.language).to.equal('r');
       expect(r_document.value).to.equal('df = data.frame()\n\n\nggplot(df)\n');
     });
@@ -154,7 +154,7 @@ describe('VirtualDocument', () => {
       let editor_position = document.transform_virtual_to_editor({
         line: 0,
         ch: 0
-      } as IVirtualPosition);
+      } as IVirtualPosition)!;
       expect(editor_position.line).to.equal(0);
       expect(editor_position.ch).to.equal(0);
 
@@ -162,7 +162,7 @@ describe('VirtualDocument', () => {
       editor_position = document.transform_virtual_to_editor({
         line: 4,
         ch: 0
-      } as IVirtualPosition);
+      } as IVirtualPosition)!;
       expect(editor_position.line).to.equal(0);
       expect(editor_position.ch).to.equal(0);
     });
@@ -198,7 +198,7 @@ describe('VirtualDocument', () => {
       // because it checks R source position, rather than checking root source positions.
 
       let editor_position =
-        foreign_document.transform_virtual_to_editor(virtual_r_1_1);
+        foreign_document.transform_virtual_to_editor(virtual_r_1_1)!;
       expect(editor_position.line).to.equal(1);
       expect(editor_position.ch).to.equal(4);
 
@@ -207,7 +207,7 @@ describe('VirtualDocument', () => {
       editor_position = foreign_document.transform_virtual_to_editor({
         line: 3,
         ch: 0
-      } as IVirtualPosition);
+      } as IVirtualPosition)!;
       // 0th editor line is 'test line in Python 2\n'
       expect(editor_position.line).to.equal(1);
       // 1st editor lines is '%R 1st test line in R line magic 2'
@@ -219,7 +219,7 @@ describe('VirtualDocument', () => {
       editor_position = foreign_document.transform_virtual_to_editor({
         line: 6,
         ch: 36
-      } as IVirtualPosition);
+      } as IVirtualPosition)!;
       // 0th editor line is 'test line in Python 3\n'
       expect(editor_position.line).to.equal(1);
       // 1st editor line is '%R -i imported_variable 1st test line in R line magic 3'
@@ -231,7 +231,7 @@ describe('VirtualDocument', () => {
       editor_position = foreign_document.transform_virtual_to_editor({
         line: 12,
         ch: 36
-      } as IVirtualPosition);
+      } as IVirtualPosition)!;
       // 0th editor line is '%%R -i imported_variable\n'
       expect(editor_position.line).to.equal(1);
       // 1st editor line is '1st test line in R cell magic 2'

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -32,7 +32,7 @@ interface IVirtualLine {
   /**
    * Where does the virtual line belongs to in the source document?
    */
-  source_line: number;
+  source_line: number | null;
   editor: CodeEditor.IEditor;
 }
 
@@ -132,7 +132,7 @@ export namespace VirtualDocument {
     foreign_code_extractors: IForeignCodeExtractorsRegistry;
     overrides_registry: ICodeOverridesRegistry;
     path: string;
-    file_extension: string;
+    file_extension: string | undefined;
     console: ILSPLogConsole;
     /**
      * Notebooks or any other aggregates of documents are not supported
@@ -218,9 +218,9 @@ export class VirtualDocument {
   public changed: Signal<VirtualDocument, VirtualDocument>;
 
   public path: string;
-  public file_extension: string;
+  public file_extension: string | undefined;
   public has_lsp_supported_file: boolean;
-  public parent?: VirtualDocument;
+  public parent?: VirtualDocument | null;
   private readonly options: VirtualDocument.IOptions;
   public update_manager: UpdateManager;
 
@@ -251,7 +251,7 @@ export class VirtualDocument {
     this.source_lines = new Map();
     this.foreign_documents = new Map();
     this.overrides_registry = options.overrides_registry;
-    this.standalone = options.standalone;
+    this.standalone = options.standalone || false;
     this.instance_id = VirtualDocument.instances_count;
     VirtualDocument.instances_count += 1;
     this.unused_standalone_documents = new DefaultMap(
@@ -289,14 +289,15 @@ export class VirtualDocument {
     this.unused_standalone_documents.clear();
     this.virtual_lines.clear();
 
-    // just to be sure
-    this.cell_magics_overrides = null;
-    this.document_info = null;
-    this.foreign_extractors = null;
-    this.foreign_extractors_registry = null;
-    this.line_magics_overrides = null;
-    this.line_blocks = null;
-    this.overrides_registry = null;
+    // just to be sure - if anything is accessed after disposal (it should not) we
+    // will get alterted by errors in the console AND this will limit memory leaks
+    this.cell_magics_overrides = null as any;
+    this.document_info = null as any;
+    this.foreign_extractors = null as any;
+    this.foreign_extractors_registry = null as any;
+    this.line_magics_overrides = null as any;
+    this.line_blocks = null as any;
+    this.overrides_registry = null as any;
   }
 
   /**
@@ -415,7 +416,7 @@ export class VirtualDocument {
   }
 
   is_within_foreign(source_position: ISourcePosition): boolean {
-    let source_line = this.source_lines.get(source_position.line);
+    let source_line = this.source_lines.get(source_position.line)!;
 
     let source_position_ce: CodeEditor.IPosition = {
       line: source_line.editor_line,
@@ -432,7 +433,7 @@ export class VirtualDocument {
   virtual_position_at_document(
     source_position: ISourcePosition
   ): IVirtualPosition {
-    let source_line = this.source_lines.get(source_position.line);
+    let source_line = this.source_lines.get(source_position.line)!;
     let virtual_line = source_line.virtual_line;
 
     // position inside the cell (block)
@@ -474,7 +475,7 @@ export class VirtualDocument {
     // if not standalone, try to append to existing document
     let foreign_exists = this.foreign_documents.has(extractor.language);
     if (!extractor.standalone && foreign_exists) {
-      foreign_document = this.foreign_documents.get(extractor.language);
+      foreign_document = this.foreign_documents.get(extractor.language)!;
       this.unused_documents.delete(foreign_document);
     } else {
       // if standalone, try to re-use existing connection to the server
@@ -482,7 +483,7 @@ export class VirtualDocument {
         extractor.language
       );
       if (extractor.standalone && unused_standalone.length > 0) {
-        foreign_document = unused_standalone.pop();
+        foreign_document = unused_standalone.pop()!;
         this.unused_documents.delete(foreign_document);
       } else {
         // if (previous document does not exists) or (extractor produces standalone documents
@@ -521,8 +522,14 @@ export class VirtualDocument {
 
       for (let result of results) {
         if (result.foreign_code !== null) {
+          // result.range should only be null if result.foregin_code is null
+          if (result.range === null) {
+            this.console.warn(
+              'Failure in foreign code extraction: `range` is null but `foreign_code` is not!'
+            );
+            continue;
+          }
           let foreign_document = this.choose_foreign_document(extractor);
-
           foreign_document_map.set(result.range, {
             virtual_line: foreign_document.last_virtual_line,
             virtual_document: foreign_document,
@@ -538,7 +545,7 @@ export class VirtualDocument {
               ce_editor: block.ce_editor
             },
             foreign_shift,
-            result.virtual_shift
+            result.virtual_shift!
           );
         }
         if (result.host_code != null) {
@@ -748,11 +755,7 @@ export class VirtualDocument {
   }
 
   transform_source_to_editor(pos: ISourcePosition): IEditorPosition {
-    if (pos == null) {
-      this.console.warn('no position available');
-      return;
-    }
-    let source_line = this.source_lines.get(pos.line);
+    let source_line = this.source_lines.get(pos.line)!;
     let editor_line = source_line.editor_line;
     let editor_shift = source_line.editor_shift;
     return {
@@ -764,17 +767,35 @@ export class VirtualDocument {
     } as IEditorPosition;
   }
 
+  /**
+  Can be null because some lines are added as padding/anchors
+  to the virtual document and those do not exist in the source document
+  and thus they are absent in the editor.
+  */
   transform_virtual_to_editor(
     virtual_position: IVirtualPosition
-  ): IEditorPosition {
+  ): IEditorPosition | null {
     let source_position = this.transform_virtual_to_source(virtual_position);
+    if (source_position == null) {
+      return null;
+    }
     return this.transform_source_to_editor(source_position);
   }
 
-  transform_virtual_to_source(position: IVirtualPosition): ISourcePosition {
+  /**
+  Can be null because some lines are added as padding/anchors
+  to the virtual document and those do not exist in the source document.
+  */
+  transform_virtual_to_source(
+    position: IVirtualPosition
+  ): ISourcePosition | null {
+    const line = this.virtual_lines.get(position.line)!.source_line;
+    if (line == null) {
+      return null;
+    }
     return {
       ch: position.ch,
-      line: this.virtual_lines.get(position.line).source_line
+      line: line
     } as ISourcePosition;
   }
 
@@ -786,24 +807,16 @@ export class VirtualDocument {
   }
 
   get_editor_at_virtual_line(pos: IVirtualPosition): CodeEditor.IEditor {
-    if (pos == null) {
-      this.console.warn('no position available');
-      return;
-    }
     let line = pos.line;
     // tolerate overshot by one (the hanging blank line at the end)
     if (!this.virtual_lines.has(line)) {
       line -= 1;
     }
-    return this.virtual_lines.get(line).editor;
+    return this.virtual_lines.get(line)!.editor;
   }
 
   get_editor_at_source_line(pos: ISourcePosition): CodeEditor.IEditor {
-    if (pos == null) {
-      this.console.warn('no position available');
-      return;
-    }
-    return this.source_lines.get(pos.line).editor;
+    return this.source_lines.get(pos.line)!.editor;
   }
 
   /**

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -13,7 +13,8 @@ import { ICodeOverridesRegistry } from '../overrides/tokens';
 import {
   IEditorPosition,
   ISourcePosition,
-  IVirtualPosition
+  IVirtualPosition,
+  PositionError
 } from '../positioning';
 import { ILSPLogConsole } from '../tokens';
 import { DefaultMap, until_ready } from '../utils';
@@ -433,7 +434,10 @@ export class VirtualDocument {
   virtual_position_at_document(
     source_position: ISourcePosition
   ): IVirtualPosition {
-    let source_line = this.source_lines.get(source_position.line)!;
+    let source_line = this.source_lines.get(source_position.line);
+    if (source_line == null) {
+      throw new PositionError('Source line not mapped to virtual position');
+    }
     let virtual_line = source_line.virtual_line;
 
     // position inside the cell (block)

--- a/packages/jupyterlab-lsp/src/virtual/editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editor.ts
@@ -100,7 +100,7 @@ export interface IVirtualEditor<T extends IEditor> {
    */
   window_coords_to_root_position(
     coordinates: IWindowCoordinates
-  ): IRootPosition;
+  ): IRootPosition | null;
 
   /**
    * Get the token at given root source position.
@@ -152,7 +152,7 @@ export class VirtualEditorManager implements ILSPVirtualEditorManager {
 
   findBestImplementation(
     editors: CodeEditor.IEditor[]
-  ): IVirtualEditorType<any> {
+  ): IVirtualEditorType<any> | null {
     // for now, we check if all editors are of the same type,
     // but it could be good enough if majority of the editors
     // had the requested type

--- a/packages/lsp-ws-connection/src/test/connection.test.ts
+++ b/packages/lsp-ws-connection/src/test/connection.test.ts
@@ -81,12 +81,13 @@ class MockSocket implements EventTarget {
   /**
    * Sends a synthetic event to the client code, for example to imitate a server response
    */
-  public dispatchEvent = (event: Event) => {
+  public dispatchEvent = (event: Event): boolean => {
     const listeners: Listener[] = this.listeners[event.type];
     if (!listeners) {
       return false;
     }
     listeners.forEach(listener => listener.call(null, event));
+    return true;
   };
 
   constructor(url: string, protocols?: string[]) {

--- a/packages/lsp-ws-connection/src/test/mock-connection.ts
+++ b/packages/lsp-ws-connection/src/test/mock-connection.ts
@@ -14,12 +14,13 @@ export class MockConnection implements ILspConnection {
   /**
    * Sends a synthetic event to the client code, for example to imitate a server response
    */
-  public dispatchEvent = (event: MessageEvent) => {
+  public dispatchEvent = (event: MessageEvent): boolean => {
     const listeners = this.listeners[event.type];
     if (!listeners) {
       return false;
     }
     listeners.forEach(listener => listener.call(null, event.data));
+    return true;
   };
 
   public sendInitialize = sinon.stub();

--- a/packages/lsp-ws-connection/src/types.ts
+++ b/packages/lsp-ws-connection/src/types.ts
@@ -22,6 +22,7 @@ export type AnyLocation =
   | lsProtocol.Location
   | lsProtocol.Location[]
   | lsProtocol.LocationLink[]
+  | undefined
   | null;
 
 export type AnyCompletion =

--- a/packages/lsp-ws-connection/src/ws-connection.ts
+++ b/packages/lsp-ws-connection/src/ws-connection.ts
@@ -88,7 +88,7 @@ export class LspWsConnection
                   this.serverCapabilities = registerServerCapability(
                     this.serverCapabilities,
                     capabilityRegistration
-                  );
+                  )!;
                 } catch (err) {
                   console.error(err);
                 }

--- a/packages/tsconfigbase.json
+++ b/packages/tsconfigbase.json
@@ -16,6 +16,7 @@
     "sourceMap": true,
     "target": "es2017",
     "skipLibCheck": true,
+    "strictNullChecks": true,
     "types": []
   }
 }

--- a/packages/tsconfigbase.json
+++ b/packages/tsconfigbase.json
@@ -19,6 +19,8 @@
     "strictNullChecks": true,
     "noImplicitThis": true,
     "strictBindCallApply": true,
+    "allowUnusedLabels": false,
+    "noFallthroughCasesInSwitch": true,
     "types": []
   }
 }

--- a/packages/tsconfigbase.json
+++ b/packages/tsconfigbase.json
@@ -21,6 +21,7 @@
     "strictBindCallApply": true,
     "allowUnusedLabels": false,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "types": []
   }
 }

--- a/packages/tsconfigbase.json
+++ b/packages/tsconfigbase.json
@@ -18,6 +18,7 @@
     "skipLibCheck": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
+    "strictBindCallApply": true,
     "types": []
   }
 }

--- a/packages/tsconfigbase.json
+++ b/packages/tsconfigbase.json
@@ -17,6 +17,7 @@
     "target": "es2017",
     "skipLibCheck": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "types": []
   }
 }


### PR DESCRIPTION
## References

Closes #130

## Code changes

`strictNullChecks` are now enabled for all packages; a number of bugs were caught thanks to this change and fixed:
- while logger extension was not required, if it was implicitly assumed thus logging all communication was broken if the logger extension was absent; this could have affected advanced developers debugging LSP in RetroLab/Notebook v7
- `window/showMessageRequest` server request was assuming that actions are always provided by the server which could have resulted in messages not showing up; now a "Dismiss" button will be added a a default action when no actions are provided by the server
- changing kernels always led to restarting of LSP connection, even if the kernel language did not change; now the connection will be retained if possible
- `markdownRenderer` is no longer implicitly required
- some potential failures of completion in edge cases (when `token.type` is missing, when line cannot be retrieved from editor) were fixed.
- diagnostics sorting with missing values for `source` and `severity` was improved and missing values will be consistently shown at the end
- diagnostics placeholder was split into `Diagnostics are not available` and `No issues detected, great job!` which will now show up properly.

In addition `noImplicitThis` ,`strictBindCallApply`, `noImplicitReturns`, `noFallthroughCasesInSwitch` are now enabled, and `allowUnusedLabels` was changed from default `undefined` (=warn) to stricter `false`.

## User-facing changes

More console warning were added for edge cases which might have been eluded our attention previously.

## Backwards-incompatible changes

Public APIs are now annotated with `undefiend` and `null` where needed; this is a non-breaking change for dependants using default `strictNullChecks: false` and might be a breaking change for anyone else with `strictNullChecks` enabled.

- `@krassowski/code-jumpers`:
   - `ILocalPosition.index` is now always required, but it is effectively ignored outside of the notebook

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
