### PR TITLE
Fix signature blur and fix formatting when no arguments are present

### DIFF
--- a/atest/05_Features/Signature.robot
+++ b/atest/05_Features/Signature.robot
@@ -6,8 +6,11 @@ Test Setup        Setup Notebook    Python    Signature.ipynb
 Test Teardown     Clean Up After Working With File    Signature.ipynb
 
 *** Variables ***
+${SIGNATURE PLUGIN ID}    @krassowski/jupyterlab-lsp:signature
 ${SIGNATURE_BOX}    css:.lsp-signature-help
 ${SIGNATURE_HIGHLIGHTED_ARG}    css:.lsp-signature-help mark
+${SIGNATURE_DETAILS_CSS}    .lsp-signature-help details
+${SIGNATURE_DETAILS}    css:${SIGNATURE_DETAILS_CSS}
 
 *** Test Cases ***
 Triggers Signature Help After A Keystroke
@@ -51,3 +54,27 @@ Invalidates On Cell Change
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
     Enter Cell Editor    2
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Not Contain Element    ${SIGNATURE_BOX}
+
+Details Should Expand On Click
+    Configure JupyterLab Plugin    {"maxLines": 4}    plugin id=${SIGNATURE PLUGIN ID}
+    Enter Cell Editor    3    line=11
+    Press Keys    None    (
+    Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
+    Wait Until Keyword Succeeds    10x    0.5s    Element Should Contain    ${SIGNATURE_BOX}    Short description.
+    Page Should Contain Element    ${SIGNATURE_DETAILS}
+    Details Should Be Collapsed     ${SIGNATURE_DETAILS_CSS}
+    Click Element    ${SIGNATURE_DETAILS}
+    Details Should Be Expanded    ${SIGNATURE_DETAILS_CSS}
+
+*** Keywords ***
+
+Details Should Be Expanded
+    [Arguments]    ${css_locator}
+    ${is_open}    Execute JavaScript    return document.querySelector('${css_locator}').open
+    Should Be True    ${is_open} == True
+
+
+Details Should Be Collapsed
+    [Arguments]    ${css_locator}
+    ${is_open}    Execute JavaScript    return document.querySelector('${css_locator}').open
+    Should Be True    ${is_open} == False

--- a/atest/examples/Signature.ipynb
+++ b/atest/examples/Signature.ipynb
@@ -27,6 +27,25 @@
    "source": [
     "list"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def with_long():\n",
+    "    \"\"\"Short description.\n",
+    "\n",
+    "    This is a longer description.\n",
+    "    The longer description is spread across several lines.\n",
+    "    This is to see the details collapse.\n",
+    "    The number of lines needed depends on `maxLines` setting.\n",
+    "    \"\"\"\n",
+    "\n",
+    "\n",
+    "with_long"
+   ]
   }
  ],
  "metadata": {

--- a/packages/jupyterlab-lsp/src/features/signature.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.spec.ts
@@ -76,7 +76,7 @@ describe('Signature', () => {
         new BrowserConsole()
       );
       expect(text).to.be.equal(
-        'str(<u>text</u>)\nCreate a new \\*string\\* object from the given object.\n'
+        'str(<u>text</u>)\n\nCreate a new \\*string\\* object from the given object.\n'
       );
     });
 
@@ -101,7 +101,7 @@ describe('Signature', () => {
         new BrowserConsole()
       );
       expect(text).to.be.equal(
-        'str(<u>text</u>)\nCreate a new \\*string\\* object from the given object.\n'
+        'str(<u>text</u>)\n\nCreate a new \\*string\\* object from the given object.\n'
       );
     });
 
@@ -126,7 +126,54 @@ describe('Signature', () => {
         new BrowserConsole()
       );
       expect(text).to.be.equal(
-        'str(<u>text</u>)\nCreate a new *string* object from the given object.'
+        'str(<u>text</u>)\n\nCreate a new *string* object from the given object.'
+      );
+    });
+
+    it('renders plaintext with details and paramaters', async () => {
+      let text = signatureToMarkdown(
+        {
+          label: 'str(text)',
+          documentation: {
+            value: 'line 1\n\nline 2\nline 3\nline 4\nline 5',
+            kind: 'plaintext'
+          },
+          parameters: [
+            {
+              label: 'text',
+              documentation: undefined
+            }
+          ],
+          activeParameter: 0
+        },
+        'python',
+        MockHighlighter,
+        new BrowserConsole(),
+        undefined,
+        4
+      );
+      expect(text).to.be.equal(
+        'str(<u>text</u>)\n\nline 1\n<details>\nline 2\nline 3\nline 4\nline 5\n</details>'
+      );
+    });
+
+    it('renders plaintext with details and no parameters', async () => {
+      let text = signatureToMarkdown(
+        {
+          label: 'str()',
+          documentation: {
+            value: 'line 1\n\nline 2\nline 3\nline 4\nline 5',
+            kind: 'plaintext'
+          }
+        },
+        'python',
+        MockHighlighter,
+        new BrowserConsole(),
+        undefined,
+        4
+      );
+      expect(text).to.be.equal(
+        '```python\nstr()\n```\n\nline 1\n<details>\nline 2\nline 3\nline 4\nline 5\n</details>'
       );
     });
   });

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -104,7 +104,6 @@ export function signatureToMarkdown(
   }
   let details = '';
   if (item.documentation) {
-    details += '\n';
     if (
       typeof item.documentation === 'string' ||
       item.documentation.kind === 'plaintext'
@@ -123,7 +122,7 @@ export function signatureToMarkdown(
       }
     } else {
       if (item.documentation.kind !== 'markdown') {
-        console.warn('Unknown MarkupContent kind:', item.documentation.kind);
+        logger.warn('Unknown MarkupContent kind:', item.documentation.kind);
       }
       details += item.documentation.value;
     }
@@ -146,7 +145,9 @@ export function signatureToMarkdown(
         details = '<details>\n' + details + '\n</details>';
       }
     }
-    markdown += details;
+    markdown += '\n\n' + details;
+  } else {
+    markdown += '\n';
   }
   return markdown;
 }
@@ -181,7 +182,7 @@ export class SignatureCM extends CodeMirrorIntegration {
     // (allowing user to select/copy from signature)
     if (
       this.isSignatureShown() &&
-      (event.target as Element).closest('.' + CLASS_NAME) === null
+      (event.relatedTarget as Element).closest('.' + CLASS_NAME) === null
     ) {
       this._hideTooltip();
     }
@@ -275,7 +276,7 @@ export class SignatureCM extends CodeMirrorIntegration {
         code.appendChild(element);
       }
     );
-    return pre.outerHTML + '\n\n';
+    return pre.outerHTML;
   }
 
   /**


### PR DESCRIPTION
## References

Follow up after #671:
- signature (and details) should be clickable but were not due to incorrect use of `target` where `relatedTarget` should be used
- label code was not rendering in signature for functions without arguments if details were present due to a missing new line

## Code changes

- use `relatedTarget` in blur event
- always add two new lines if details are, not only when highlighting active arguments

## User-facing changes

Before:

![before](https://user-images.githubusercontent.com/5832902/147477465-12268155-5acf-4747-9a64-d4e861a18093.gif)

After:

![after](https://user-images.githubusercontent.com/5832902/147477452-1d0d52ba-90d5-4fe5-bfc9-3d60db0148f2.gif)


## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
