### PR TITLE
Enable simple pre-filtering of completion matches

### DIFF
--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -170,6 +170,7 @@ Does Not Autocomplete If Multiple Options
     Completer Should Suggest    copy
 
 User Can Select Lowercase After Starting Uppercase
+    Configure JupyterLab Plugin    {"caseSensitive": false}    plugin id=${COMPLETION PLUGIN ID}
     # `from time import Tim<tab>` → `from time import time`
     Enter Cell Editor    5    line=1
     Trigger Completer

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -12,13 +12,12 @@ ${KERNEL_BUSY_INDICATOR}    css:.jp-NotebookPanel-toolbar div[title="Kernel Busy
 
 *** Test Cases ***
 Works When Kernel Is Idle
-    Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForBusyKernel": false}    plugin id=${COMPLETION PLUGIN ID}
-    [Documentation]    The suggestions from kernel and LSP should get integrated.
+    Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForBusyKernel": false, "caseSensitive": false}    plugin id=${COMPLETION PLUGIN ID}
+    [Documentation]    The suggestions from kernel and LSP should get integrated; operates in case insensitive mode
     Enter Cell Editor    1    line=2
     Capture Page Screenshot    01-entered-cell.png
     Trigger Completer
     Capture Page Screenshot    02-completions-shown.png
-    # lowercase and uppercase suggestions:
     Completer Should Suggest    TabError
     # this comes from LSP:
     Completer Should Suggest    test
@@ -28,6 +27,15 @@ Works When Kernel Is Idle
     Capture Page Screenshot    03-completion-confirmed.png
     ${content} =    Get Cell Editor Content    1
     Should Contain    ${content}    TabError
+
+Filters Completions In Case Sensitive Mode
+    Configure JupyterLab Plugin    {"caseSensitive": true}    plugin id=${COMPLETION PLUGIN ID}
+    [Documentation]    Completions filtering is case-sensitive when caseSensitive is true
+    Enter Cell Editor    1    line=2
+    Trigger Completer
+    Completer Should Suggest    test
+    Completer Should Not Suggest    TabError
+
 
 Can Prioritize Kernel Completions
     Configure JupyterLab Plugin    {"kernelCompletionsFirst": true, "kernelResponseTimeout": -1}    plugin id=${COMPLETION PLUGIN ID}
@@ -212,7 +220,7 @@ Triggers Completer On Dot
     Completer Should Suggest    append
 
 Material Theme Works
-    Configure JupyterLab Plugin    {"theme": "material"}    plugin id=${COMPLETION PLUGIN ID}
+    Configure JupyterLab Plugin    {"theme": "material", "caseSensitive": false}    plugin id=${COMPLETION PLUGIN ID}
     Capture Page Screenshot    01-configured.png
     Enter Cell Editor    1    line=2
     Trigger Completer
@@ -223,7 +231,7 @@ Material Theme Works
     Completer Should Include Icon    lsp:material-class-light
 
 VSCode Theme Works
-    Configure JupyterLab Plugin    {"theme": "vscode"}    plugin id=${COMPLETION PLUGIN ID}
+    Configure JupyterLab Plugin    {"theme": "vscode", "caseSensitive": false}    plugin id=${COMPLETION PLUGIN ID}
     Capture Page Screenshot    01-configured.png
     Enter Cell Editor    1    line=2
     Trigger Completer
@@ -236,7 +244,7 @@ VSCode Dark Theme Works
     Lab Command    Use Theme: JupyterLab Dark
     Wait For Splash
     Capture Page Screenshot    00-theme-changed.png
-    Configure JupyterLab Plugin    {"theme": "vscode"}    plugin id=${COMPLETION PLUGIN ID}
+    Configure JupyterLab Plugin    {"theme": "vscode", "caseSensitive": false}    plugin id=${COMPLETION PLUGIN ID}
     Capture Page Screenshot    01-configured.png
     Open ${file} in ${MENU NOTEBOOK}
     Wait Until Fully Initialized
@@ -249,7 +257,7 @@ VSCode Dark Theme Works
     Wait For Splash
 
 Works Without A Theme
-    Configure JupyterLab Plugin    {"theme": null}    plugin id=${COMPLETION PLUGIN ID}
+    Configure JupyterLab Plugin    {"theme": null, "caseSensitive": false}    plugin id=${COMPLETION PLUGIN ID}
     Capture Page Screenshot    01-configured.png
     Enter Cell Editor    1    line=2
     Trigger Completer
@@ -258,7 +266,7 @@ Works Without A Theme
     Wait Until Page Contains Element    ${COMPLETER_BOX} .jp-Completer-monogram
 
 Works With Incorrect Theme
-    Configure JupyterLab Plugin    {"theme": "a-non-existing-theme"}    plugin id=${COMPLETION PLUGIN ID}
+    Configure JupyterLab Plugin    {"theme": "a-non-existing-theme", "caseSensitive": false}    plugin id=${COMPLETION PLUGIN ID}
     Capture Page Screenshot    01-configured.png
     Enter Cell Editor    1    line=2
     Trigger Completer

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -38,7 +38,8 @@ Filters Completions In Case Sensitive Mode
 
 
 Can Prioritize Kernel Completions
-    Configure JupyterLab Plugin    {"kernelCompletionsFirst": true, "kernelResponseTimeout": -1}    plugin id=${COMPLETION PLUGIN ID}
+    # note: disabling pre-filtering to get ranking without match scoring
+    Configure JupyterLab Plugin    {"kernelCompletionsFirst": true, "kernelResponseTimeout": -1, "preFilterMatches": false}    plugin id=${COMPLETION PLUGIN ID}
     Enter Cell Editor    1    line=2
     Trigger Completer
     Completer Should Suggest    %%timeit
@@ -47,7 +48,8 @@ Can Prioritize Kernel Completions
     Should Be True    ${kernel_position} < ${lsp_position}
 
 Can Prioritize LSP Completions
-    Configure JupyterLab Plugin    {"kernelCompletionsFirst": false, "kernelResponseTimeout": -1}    plugin id=${COMPLETION PLUGIN ID}
+    # note: disabling pre-filtering to get ranking without match scoring
+    Configure JupyterLab Plugin    {"kernelCompletionsFirst": false, "kernelResponseTimeout": -1, "preFilterMatches": false}    plugin id=${COMPLETION PLUGIN ID}
     Enter Cell Editor    1    line=2
     Trigger Completer
     Completer Should Suggest    %%timeit

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -76,6 +76,12 @@
       "type": "boolean",
       "description": "Should perfect matches be included in the completion suggestions list?"
     },
+    "preFilterMatches": {
+      "title": "Pre-filter matches",
+      "default": true,
+      "type": "boolean",
+      "description": "Should matches be pre-filtered to ensure typed token is a prefix of the match?"
+    },
     "labelExtra": {
       "title": "Text to display next to completion label",
       "default": "auto",

--- a/packages/jupyterlab-lsp/src/features/completion/completion.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion.ts
@@ -130,6 +130,8 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
           this.settings.composite.caseSensitive;
         this.model.settings.includePerfectMatches =
           this.settings.composite.includePerfectMatches;
+        this.model.settings.preFilterMatches =
+          this.settings.composite.preFilterMatches;
       }
     });
   }
@@ -285,7 +287,8 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
     completer.addClass('lsp-completer');
     completer.model = new LSPCompleterModel({
       caseSensitive: this.settings.composite.caseSensitive,
-      includePerfectMatches: this.settings.composite.includePerfectMatches
+      includePerfectMatches: this.settings.composite.includePerfectMatches,
+      preFilterMatches: this.settings.composite.preFilterMatches
     });
   }
 

--- a/packages/jupyterlab-lsp/src/features/completion/model.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.ts
@@ -54,7 +54,15 @@ export class GenericCompleterModel<
       // set initial query to pre-filter items; in future we should use:
       // https://github.com/jupyterlab/jupyterlab/issues/9763#issuecomment-1001603348
       const { start, end } = this.cursor;
-      this.query = this.current.text.substring(start, end);
+      let query = this.current.text.substring(start, end).trim();
+      // special case for "Completes Paths In Strings" test case
+      if (query.startsWith('"') || query.startsWith("'")) {
+        query = query.substring(1);
+      }
+      if (query.endsWith('"') || query.endsWith("'")) {
+        query = query.substring(0, -1);
+      }
+      this.query = query;
     }
   }
 

--- a/packages/jupyterlab-lsp/src/features/completion/model.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.ts
@@ -49,6 +49,13 @@ export class GenericCompleterModel<
 
   setCompletionItems(newValue: T[]) {
     super.setCompletionItems!(newValue);
+
+    if (this.settings.preFilterMatches && this.current && this.cursor) {
+      // set initial query to pre-filter items; in future we should use:
+      // https://github.com/jupyterlab/jupyterlab/issues/9763#issuecomment-1001603348
+      const { start, end } = this.cursor;
+      this.query = this.current.text.substring(start, end);
+    }
   }
 
   private _markFragment(value: string): string {
@@ -180,10 +187,15 @@ export namespace GenericCompleterModel {
      * Whether perfect matches should be included (default = true)
      */
     includePerfectMatches?: boolean;
+    /**
+     * Wheteher matches should be pre-filtered (default = true)
+     */
+    preFilterMatches?: boolean;
   }
   export const defaultOptions: IOptions = {
     caseSensitive: true,
-    includePerfectMatches: true
+    includePerfectMatches: true,
+    preFilterMatches: true
   };
 }
 


### PR DESCRIPTION
## References

Initial step for #728 - as we do not use `textEdit` just yet, we can get away with simple pre-filtering; in case if it is detrimental for some servers it can be disabled in the settings. This will be reworked once we solve https://github.com/jupyterlab/jupyterlab/issues/9763#issuecomment-1001603348.

## Code changes

Add `preFilterMatches` and pre-filter based on the token part derived from the current editor content and cursor position.

## User-facing changes

Completions will be usable in typescript server (among others).

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
