### PR TITLE
Add support for diagnostic tags from LSP 3.15

### DIFF
--- a/atest/05_Features/Diagnostics.robot
+++ b/atest/05_Features/Diagnostics.robot
@@ -9,5 +9,5 @@ Resource          ../Keywords.robot
 
 *** Test Cases ***
 Diagnostics with deprecated tag have strike-through decoration
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="Use new_func instead"]    timeout=25s
+    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="is deprecated"]    timeout=25s
     Page Should Contain Element    css:.cm-lsp-diagnostic-tag-Deprecated

--- a/atest/05_Features/Diagnostics.robot
+++ b/atest/05_Features/Diagnostics.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Suite Setup       Setup Suite For Screenshots    diagnostics
+Force Tags        feature:diagnostics
+Test Setup        Setup Notebook    Python    Diagnostic.ipynb
+Test Teardown     Clean Up After Working With File    Diagnostic.ipynb
+Resource          ../Keywords.robot
+
+# note: diagnostics are also tested in 01_Editor and 04_Interface/DiagnosticsPanel.robot
+
+*** Test Cases ***
+Diagnostics with deprecated tag have strike-through decoration
+    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="Use new_func instead"]    timeout=25s
+    Page Should Contain Element    css:.cm-lsp-diagnostic-tag-Deprecated

--- a/atest/examples/Diagnostic.ipynb
+++ b/atest/examples/Diagnostic.ipynb
@@ -48,11 +48,28 @@
     "# Foo\n",
     "above, one `hint`"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from deprecated import deprecated\n",
+    "\n",
+    "\n",
+    "@deprecated('Use new_func instead.')\n",
+    "def old_func():\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "old_func"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/atest/examples/Diagnostic.ipynb
+++ b/atest/examples/Diagnostic.ipynb
@@ -55,15 +55,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from deprecated import deprecated\n",
-    "\n",
-    "\n",
-    "@deprecated('Use new_func instead.')\n",
-    "def old_func():\n",
-    "    pass\n",
-    "\n",
-    "\n",
-    "old_func"
+    "%%javascript\n",
+    "/**\n",
+    " * @deprecated\n",
+    " */\n",
+    "function oldFunc() {}\n",
+    "oldFunc"
    ]
   }
  ],

--- a/packages/jupyterlab-lsp/src/connection.ts
+++ b/packages/jupyterlab-lsp/src/connection.ts
@@ -19,7 +19,7 @@ import type * as rpc from 'vscode-jsonrpc';
 import type * as lsp from 'vscode-languageserver-protocol';
 import type { MessageConnection } from 'vscode-ws-jsonrpc';
 
-import { CompletionItemTag } from './lsp';
+import { CompletionItemTag, DiagnosticTag } from './lsp';
 import { ILSPLogConsole } from './tokens';
 import { until_ready } from './utils';
 
@@ -426,6 +426,11 @@ export class LSPConnection extends LspWsConnection {
             },
             contextSupport: false
           },
+          publishDiagnostics: {
+            tagSupport: {
+              valueSet: [DiagnosticTag.Deprecated, DiagnosticTag.Unnecessary]
+            }
+          },
           signatureHelp: {
             dynamicRegistration: true,
             signatureInformation: {
@@ -448,7 +453,7 @@ export class LSPConnection extends LspWsConnection {
             dynamicRegistration: true,
             linkSupport: true
           }
-        } as lsp.ClientCapabilities,
+        } as lsp.TextDocumentClientCapabilities,
         workspace: {
           didChangeConfiguration: {
             dynamicRegistration: true

--- a/packages/jupyterlab-lsp/src/connection.ts
+++ b/packages/jupyterlab-lsp/src/connection.ts
@@ -19,6 +19,7 @@ import type * as rpc from 'vscode-jsonrpc';
 import type * as lsp from 'vscode-languageserver-protocol';
 import type { MessageConnection } from 'vscode-ws-jsonrpc';
 
+import { CompletionItemTag } from './lsp';
 import { ILSPLogConsole } from './tokens';
 import { until_ready } from './utils';
 
@@ -390,6 +391,74 @@ export class LSPConnection extends LspWsConnection {
       this.constructNotificationHandlers<ServerNotifications>(
         Method.ServerNotification
       );
+  }
+
+  /**
+   * Initialization parameters to be sent to the language server.
+   * Subclasses can overload this when adding more features.
+   */
+  protected initializeParams(): lsp.InitializeParams {
+    return {
+      ...super.initializeParams(),
+      capabilities: {
+        textDocument: {
+          hover: {
+            dynamicRegistration: true,
+            contentFormat: ['markdown', 'plaintext']
+          },
+          synchronization: {
+            dynamicRegistration: true,
+            willSave: false,
+            didSave: true,
+            willSaveWaitUntil: false
+          },
+          completion: {
+            dynamicRegistration: true,
+            completionItem: {
+              snippetSupport: false,
+              commitCharactersSupport: true,
+              documentationFormat: ['markdown', 'plaintext'],
+              deprecatedSupport: true,
+              preselectSupport: false,
+              tagSupport: {
+                valueSet: [CompletionItemTag.Deprecated]
+              }
+            },
+            contextSupport: false
+          },
+          signatureHelp: {
+            dynamicRegistration: true,
+            signatureInformation: {
+              documentationFormat: ['markdown', 'plaintext']
+            }
+          },
+          declaration: {
+            dynamicRegistration: true,
+            linkSupport: true
+          },
+          definition: {
+            dynamicRegistration: true,
+            linkSupport: true
+          },
+          typeDefinition: {
+            dynamicRegistration: true,
+            linkSupport: true
+          },
+          implementation: {
+            dynamicRegistration: true,
+            linkSupport: true
+          }
+        } as lsp.ClientCapabilities,
+        workspace: {
+          didChangeConfiguration: {
+            dynamicRegistration: true
+          }
+        } as lsp.WorkspaceClientCapabilities
+      } as lsp.ClientCapabilities,
+      initializationOptions: null,
+      processId: null,
+      workspaceFolders: null
+    };
   }
 
   sendOpenWhenReady(documentInfo: IDocumentInfo) {

--- a/packages/jupyterlab-lsp/src/lsp.ts
+++ b/packages/jupyterlab-lsp/src/lsp.ts
@@ -5,6 +5,11 @@ export enum DiagnosticSeverity {
   Hint = 4
 }
 
+export enum DiagnosticTag {
+  Unnecessary = 1,
+  Deprecated = 2
+}
+
 export enum CompletionItemKind {
   Text = 1,
   Method = 2,

--- a/packages/jupyterlab-lsp/src/lsp.ts
+++ b/packages/jupyterlab-lsp/src/lsp.ts
@@ -10,6 +10,10 @@ export enum DiagnosticTag {
   Deprecated = 2
 }
 
+export enum CompletionItemTag {
+  Deprecated = 1
+}
+
 export enum CompletionItemKind {
   Text = 1,
   Method = 2,

--- a/packages/jupyterlab-lsp/style/highlight.css
+++ b/packages/jupyterlab-lsp/style/highlight.css
@@ -9,6 +9,21 @@
   text-decoration-skip-ink: none;
 }
 
+.cm-lsp-diagnostic-tag-Unused {
+  /*
+   * LSP: "Clients are allowed to render diagnostics with this tag faded out instead of having an error squiggle."
+   */
+  opacity: 0.85;
+  text-decoration: none !important;
+}
+
+.cm-lsp-diagnostic-tag-Deprecated {
+  /*
+   * LSP: "Clients are allowed to rendered diagnostics with this tag strike through."
+   */
+  text-decoration: line-through !important;
+}
+
 .cm-lsp-diagnostic-Error {
   /*
     "wavy" would be ideal, but there seems to be a bug in Chrome which makes it

--- a/packages/lsp-ws-connection/src/ws-connection.ts
+++ b/packages/lsp-ws-connection/src/ws-connection.ts
@@ -1,7 +1,7 @@
 import * as events from 'events';
 
 import type * as protocol from 'vscode-languageserver-protocol';
-import { CompletionItemTag, LocationLink } from 'vscode-languageserver-types';
+import type { LocationLink } from 'vscode-languageserver-types';
 import { ConsoleLogger, MessageConnection, listen } from 'vscode-ws-jsonrpc';
 
 import {
@@ -145,66 +145,11 @@ export class LspWsConnection
 
   /**
    * Initialization parameters to be sent to the language server.
-   * Subclasses can overload this when adding more features.
+   * Subclasses should override this when adding more features.
    */
   protected initializeParams(): protocol.InitializeParams {
     return {
-      capabilities: {
-        textDocument: {
-          hover: {
-            dynamicRegistration: true,
-            contentFormat: ['markdown', 'plaintext']
-          },
-          synchronization: {
-            dynamicRegistration: true,
-            willSave: false,
-            didSave: true,
-            willSaveWaitUntil: false
-          },
-          completion: {
-            dynamicRegistration: true,
-            completionItem: {
-              snippetSupport: false,
-              commitCharactersSupport: true,
-              documentationFormat: ['markdown', 'plaintext'],
-              deprecatedSupport: true,
-              preselectSupport: false,
-              tagSupport: {
-                valueSet: [CompletionItemTag.Deprecated]
-              }
-            },
-            contextSupport: false
-          },
-          signatureHelp: {
-            dynamicRegistration: true,
-            signatureInformation: {
-              documentationFormat: ['markdown', 'plaintext']
-            }
-          },
-          declaration: {
-            dynamicRegistration: true,
-            linkSupport: true
-          },
-          definition: {
-            dynamicRegistration: true,
-            linkSupport: true
-          },
-          typeDefinition: {
-            dynamicRegistration: true,
-            linkSupport: true
-          },
-          implementation: {
-            dynamicRegistration: true,
-            linkSupport: true
-          }
-        } as protocol.ClientCapabilities,
-        workspace: {
-          didChangeConfiguration: {
-            dynamicRegistration: true
-          }
-        } as protocol.WorkspaceClientCapabilities
-      } as protocol.ClientCapabilities,
-      initializationOptions: null,
+      capabilities: {} as protocol.ClientCapabilities,
       processId: null,
       rootUri: this.rootUri,
       workspaceFolders: null

--- a/requirements/github-actions.yml
+++ b/requirements/github-actions.yml
@@ -37,3 +37,5 @@ dependencies:
   - robotframework >=4
   - robotframework-seleniumlibrary
   - python-lsp-server
+  - pip:
+      - git+https://github.com/krassowski/pyls-memestra.git@add-deprecated-tag

--- a/requirements/github-actions.yml
+++ b/requirements/github-actions.yml
@@ -37,5 +37,3 @@ dependencies:
   - robotframework >=4
   - robotframework-seleniumlibrary
   - python-lsp-server
-  - pip:
-      - git+https://github.com/krassowski/pyls-memestra.git@add-deprecated-tag


### PR DESCRIPTION
## References

Add support for diagnostic tags ([`DiagnosticTag`](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#diagnosticTag)) from LSP 3.15.

## Code changes

Adds two new CSS classes:
-  `cm-lsp-diagnostic-tag-Unused`
- `cm-lsp-diagnostic-tag-Deprecated`

moves `severity` determination code so it is not run if we don't need to update the diagnostic.

## User-facing changes

1. Strike-through is shown for deprecated items:
    ![Screenshot from 2021-12-30 16-27-32](https://user-images.githubusercontent.com/5832902/147770214-c3311054-84cc-4426-beff-025f6e791bc4.png)
2. Unused code is faded out:
    TBD

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
