### PR TITLE
Move client capabilities to features

### DIFF
--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -36,7 +36,6 @@ Filters Completions In Case Sensitive Mode
     Completer Should Suggest    test
     Completer Should Not Suggest    TabError
 
-
 Can Prioritize Kernel Completions
     # note: disabling pre-filtering to get ranking without match scoring
     Configure JupyterLab Plugin    {"kernelCompletionsFirst": true, "kernelResponseTimeout": -1, "preFilterMatches": false}    plugin id=${COMPLETION PLUGIN ID}

--- a/atest/05_Features/Diagnostics.robot
+++ b/atest/05_Features/Diagnostics.robot
@@ -4,7 +4,6 @@ Force Tags        feature:diagnostics
 Test Setup        Setup Notebook    Python    Diagnostic.ipynb
 Test Teardown     Clean Up After Working With File    Diagnostic.ipynb
 Resource          ../Keywords.robot
-
 # note: diagnostics are also tested in 01_Editor and 04_Interface/DiagnosticsPanel.robot
 
 *** Test Cases ***

--- a/atest/05_Features/Signature.robot
+++ b/atest/05_Features/Signature.robot
@@ -62,17 +62,15 @@ Details Should Expand On Click
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
     Wait Until Keyword Succeeds    10x    0.5s    Element Should Contain    ${SIGNATURE_BOX}    Short description.
     Page Should Contain Element    ${SIGNATURE_DETAILS}
-    Details Should Be Collapsed     ${SIGNATURE_DETAILS_CSS}
+    Details Should Be Collapsed    ${SIGNATURE_DETAILS_CSS}
     Click Element    ${SIGNATURE_DETAILS}
     Details Should Be Expanded    ${SIGNATURE_DETAILS_CSS}
 
 *** Keywords ***
-
 Details Should Be Expanded
     [Arguments]    ${css_locator}
     ${is_open}    Execute JavaScript    return document.querySelector('${css_locator}').open
     Should Be True    ${is_open} == True
-
 
 Details Should Be Collapsed
     [Arguments]    ${css_locator}

--- a/docs/Extending.ipynb
+++ b/docs/Extending.ipynb
@@ -34,6 +34,8 @@
     "  `CodeMirrorIntegration` class.\n",
     "- `labIntegration`: an optional object integrating feature with the JupyterLab\n",
     "  interface\n",
+    "- `capabilities`: an optional object defining the [client\n",
+    "  capabilities][clientcapabilities] implemented by your feature,\n",
     "- optional fields for easy integration of some of the common JupyterLab systems,\n",
     "  such as:\n",
     "  - settings system\n",
@@ -46,7 +48,10 @@
     "#### How to override the default implementation of a feature?\n",
     "\n",
     "You can specify a list of extensions to be disabled the the feature manager\n",
-    "passing their plugin identifiers in `supersedes` field of `IFeatureOptions`."
+    "passing their plugin identifiers in `supersedes` field of `IFeatureOptions`.\n",
+    "\n",
+    "[clientCapabilities]:\n",
+    "https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#clientCapabilities]"
    ]
   },
   {

--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -4,6 +4,7 @@ import type * as protocol from 'vscode-languageserver-protocol';
 
 import { AskServersToSendTraceNotifications } from './_plugin';
 import type * as ConnectionModuleType from './connection';
+import { ClientCapabilities } from './lsp';
 import {
   ILSPLogConsole,
   ILanguageServerManager,
@@ -29,6 +30,10 @@ export interface ISocketConnectionOptions {
    * Path to the document in the JupyterLab space
    */
   document_path: string;
+  /**
+   * LSP capabilities describing currently supported features
+   */
+  capabilities: ClientCapabilities;
 }
 
 /**
@@ -127,7 +132,7 @@ export class DocumentConnectionManager {
     options: ISocketConnectionOptions
   ): Promise<ConnectionModuleType.LSPConnection> {
     this.console.log('Connection Socket', options);
-    let { virtual_document, language } = options;
+    let { virtual_document, language, capabilities } = options;
 
     this.connect_document_signals(virtual_document);
 
@@ -153,7 +158,8 @@ export class DocumentConnectionManager {
       language_server_id!,
       uris,
       this.on_new_connection,
-      this.console
+      this.console,
+      capabilities
     );
 
     // if connecting for the first time, all documents subsequent documents will
@@ -469,7 +475,8 @@ namespace Private {
     language_server_id: TLanguageServerId,
     uris: DocumentConnectionManager.IURIs,
     onCreate: (connection: ConnectionModuleType.LSPConnection) => void,
-    console: ILSPLogConsole
+    console: ILSPLogConsole,
+    capabilities: ClientCapabilities
   ): Promise<ConnectionModuleType.LSPConnection> {
     if (_promise == null) {
       // TODO: consider lazy-loading _only_ the modules that _must_ be webpacked
@@ -489,7 +496,8 @@ namespace Private {
         serverUri: uris.server,
         rootUri: uris.base,
         serverIdentifier: language_server_id,
-        console: console
+        console: console,
+        capabilities: capabilities
       });
       // TODO: remove remaining unbounded users of connection.on
       connection.setMaxListeners(999);

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -258,7 +258,8 @@ function FeatureSupport<TBase extends TestEnvironmentConstructor>(Base: TBase) {
         serverUri: 'ws://localhost:8080',
         rootUri: 'file:///unit-test',
         serverIdentifier: DEFAULT_SERVER_ID,
-        console: new BrowserConsole()
+        console: new BrowserConsole(),
+        capabilities: {}
       });
     }
 

--- a/packages/jupyterlab-lsp/src/feature.ts
+++ b/packages/jupyterlab-lsp/src/feature.ts
@@ -8,6 +8,7 @@ import { Signal } from '@lumino/signaling';
 import { StatusMessage, WidgetAdapter } from './adapters/adapter';
 import { CommandEntryPoint, ICommandContext } from './command_manager';
 import { LSPConnection } from './connection';
+import { ClientCapabilities } from './lsp';
 import { IRootPosition } from './positioning';
 import { VirtualDocument } from './virtual/document';
 import { IEditorChange, IVirtualEditor } from './virtual/editor';
@@ -123,6 +124,10 @@ export interface IFeature {
     IEditorName,
     IFeatureEditorIntegrationConstructor<IVirtualEditor<IEditor>>
   >;
+  /**
+   * LSP capabilities implemented by the feature.
+   */
+  capabilities?: ClientCapabilities;
   /**
    * Command specification, including context menu placement options.
    */

--- a/packages/jupyterlab-lsp/src/features/completion/index.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/index.ts
@@ -11,6 +11,7 @@ import { ILSPCompletionThemeManager } from '@krassowski/completion-theme/lib/typ
 import completionSvg from '../../../style/icons/completion.svg';
 import { CodeCompletion as LSPCompletionSettings } from '../../_completion';
 import { FeatureSettings } from '../../feature';
+import { CompletionItemTag } from '../../lsp';
 import {
   ILSPAdapterManager,
   ILSPFeatureManager,
@@ -66,7 +67,25 @@ export const COMPLETION_PLUGIN: JupyterFrontEndPlugin<void> = {
         id: FEATURE_ID,
         name: 'LSP Completion',
         labIntegration: labIntegration,
-        settings: settings
+        settings: settings,
+        capabilities: {
+          textDocument: {
+            completion: {
+              dynamicRegistration: true,
+              completionItem: {
+                snippetSupport: false,
+                commitCharactersSupport: true,
+                documentationFormat: ['markdown', 'plaintext'],
+                deprecatedSupport: true,
+                preselectSupport: false,
+                tagSupport: {
+                  valueSet: [CompletionItemTag.Deprecated]
+                }
+              },
+              contextSupport: false
+            }
+          }
+        }
       }
     });
   }

--- a/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
@@ -6,6 +6,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 
 import { FeatureSettings, IFeatureCommand } from '../../feature';
+import { DiagnosticTag } from '../../lsp';
 import { ILSPFeatureManager, PLUGIN_ID } from '../../tokens';
 
 import {
@@ -65,6 +66,15 @@ export const DIAGNOSTICS_PLUGIN: JupyterFrontEndPlugin<void> = {
           ['CodeMirrorEditor', DiagnosticsCM]
         ]),
         id: FEATURE_ID,
+        capabilities: {
+          textDocument: {
+            publishDiagnostics: {
+              tagSupport: {
+                valueSet: [DiagnosticTag.Deprecated, DiagnosticTag.Unnecessary]
+              }
+            }
+          }
+        },
         name: 'LSP Diagnostics',
         settings: settings,
         commands: COMMANDS(trans)

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -611,7 +611,15 @@ export const HOVER_PLUGIN: JupyterFrontEndPlugin<void> = {
         id: FEATURE_ID,
         name: 'LSP Hover tooltip',
         labIntegration: labIntegration,
-        settings: settings
+        settings: settings,
+        capabilities: {
+          textDocument: {
+            hover: {
+              dynamicRegistration: true,
+              contentFormat: ['markdown', 'plaintext']
+            }
+          }
+        }
       }
     });
   }

--- a/packages/jupyterlab-lsp/src/features/jump_to.ts
+++ b/packages/jupyterlab-lsp/src/features/jump_to.ts
@@ -340,7 +340,27 @@ export const JUMP_PLUGIN: JupyterFrontEndPlugin<void> = {
         id: FEATURE_ID,
         name: 'Jump to definition',
         labIntegration: labIntegration,
-        settings: settings
+        settings: settings,
+        capabilities: {
+          textDocument: {
+            declaration: {
+              dynamicRegistration: true,
+              linkSupport: true
+            },
+            definition: {
+              dynamicRegistration: true,
+              linkSupport: true
+            },
+            typeDefinition: {
+              dynamicRegistration: true,
+              linkSupport: true
+            },
+            implementation: {
+              dynamicRegistration: true,
+              linkSupport: true
+            }
+          }
+        }
       }
     });
   }

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -488,7 +488,17 @@ export const SIGNATURE_PLUGIN: JupyterFrontEndPlugin<void> = {
         id: FEATURE_ID,
         name: 'LSP Function signature',
         labIntegration: labIntegration,
-        settings: settings
+        settings: settings,
+        capabilities: {
+          textDocument: {
+            signatureHelp: {
+              dynamicRegistration: true,
+              signatureInformation: {
+                documentationFormat: ['markdown', 'plaintext']
+              }
+            }
+          }
+        }
       }
     });
   }

--- a/packages/jupyterlab-lsp/src/lsp.ts
+++ b/packages/jupyterlab-lsp/src/lsp.ts
@@ -1,3 +1,11 @@
+import type * as lsp from 'vscode-languageserver-protocol';
+
+/** Workaround to silence a bug in https://github.com/microsoft/vscode-languageserver-node/pull/720 */
+export type ClientCapabilities = Omit<
+  lsp.ClientCapabilities,
+  'textDocument'
+> & { textDocument?: Omit<lsp.TextDocumentClientCapabilities, 'moniker'> };
+
 export enum DiagnosticSeverity {
   Error = 1,
   Warning = 2,


### PR DESCRIPTION
## References

This is a pre-requisite of #76 step 3, and enables third-party extensions to register the client capabilities they provide with the server (which is essential for some servers to return relevant responses).

## Code changes

- adds optional `capabilities?: ClientCapabilities` to `IFeature` public interface
- surfaces the capabilities from `connection` through `connection_manager` up to `adapter`
- in adapter the capabilities of active features are merged

## User-facing changes

- For servers which optimize responses/work based on client capabilities the performance might be slightly increased when specific features are disabled

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
