### PR TITLE
Fix/improve schema for settings editor

### DIFF
--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -42,8 +42,13 @@
       "description": "The time to wait for the kernel completions suggestions in milliseconds. Set to 0 to disable kernel completions, or to -1 to wait indefinitely (not recommended)."
     },
     "disableCompletionsFrom": {
+      "title": "Disable completions by source",
       "description": "The sources from which to exclude completion from. Possible values include 'Kernel', 'LSP'.",
       "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["Kernel", "LSP"]
+      },
       "default": [],
       "uniqueItems": true
     },
@@ -62,6 +67,7 @@
     "kernelCompletionsFirst": {
       "title": "Prioritize completions from kernel",
       "default": false,
+      "type": "boolean",
       "description": "In case of ties when sorting completions, should the kernel completions receive higher priority than the language server completions?"
     },
     "caseSensitive": {
@@ -110,38 +116,36 @@
         "undefinitializer": "Constant",
         "base.devnull": "Constant"
       },
-      "patternProperties": {
-        "^.*$": {
-          "type": "string",
-          "enum": [
-            "Kernel",
-            "Text",
-            "Method",
-            "Function",
-            "Constructor",
-            "Field",
-            "Variable",
-            "Class",
-            "Interface",
-            "Module",
-            "Property",
-            "Unit",
-            "Value",
-            "Enum",
-            "Keyword",
-            "Snippet",
-            "Color",
-            "File",
-            "Reference",
-            "Folder",
-            "EnumMember",
-            "Constant",
-            "Struct",
-            "Event",
-            "Operator",
-            "TypeParameter"
-          ]
-        }
+      "additionalProperties": {
+        "type": "string",
+        "enum": [
+          "Kernel",
+          "Text",
+          "Method",
+          "Function",
+          "Constructor",
+          "Field",
+          "Variable",
+          "Class",
+          "Interface",
+          "Module",
+          "Property",
+          "Unit",
+          "Value",
+          "Enum",
+          "Keyword",
+          "Snippet",
+          "Color",
+          "File",
+          "Reference",
+          "Folder",
+          "EnumMember",
+          "Constant",
+          "Struct",
+          "Event",
+          "Operator",
+          "TypeParameter"
+        ]
       }
     },
     "disable": {

--- a/packages/jupyterlab-lsp/schema/highlights.json
+++ b/packages/jupyterlab-lsp/schema/highlights.json
@@ -9,6 +9,7 @@
       "title": "Debouncer delay",
       "type": "number",
       "default": 250,
+      "minimum": 0,
       "description": "Number of milliseconds to delay sending out the highlights request to the language server; you can get better responsiveness adjusting this value, but setting it to zero can actually slow it down as the server might get overwhelmed when moving the cursor."
     },
     "removeOnBlur": {

--- a/packages/jupyterlab-lsp/schema/hover.json
+++ b/packages/jupyterlab-lsp/schema/hover.json
@@ -16,12 +16,14 @@
       "title": "Throttler delay",
       "type": "number",
       "default": 50,
+      "minimum": 0,
       "description": "Number of milliseconds to delay sending out the hover request to the language server; you can get better responsiveness adjusting this value, but setting it to zero can actually slow it down as the server might get overwhelmed when moving the mouse over the code."
     },
     "cacheSize": {
       "title": "Cache size",
       "type": "number",
       "default": 25,
+      "minimum": 0,
       "description": "Up to how many hover responses should be cached at any given time. The cache being is invalidated after any change in the editor."
     },
     "disable": {

--- a/packages/jupyterlab-lsp/schema/plugin.json
+++ b/packages/jupyterlab-lsp/schema/plugin.json
@@ -6,7 +6,6 @@
   "type": "object",
   "definitions": {
     "language-server": {
-      "title": "Language Server",
       "description": "Client and server configurations for a single language server",
       "type": "object",
       "default": {},
@@ -15,7 +14,8 @@
           "title": "Language Server Configurations",
           "description": "Configuration to be sent to language server over LSP when initialized: see the specific language server's documentation for more",
           "type": "object",
-          "default": {}
+          "default": {},
+          "additionalProperties": true
         },
         "priority": {
           "title": "Priority of the server",

--- a/packages/jupyterlab-lsp/schema/syntax_highlighting.json
+++ b/packages/jupyterlab-lsp/schema/syntax_highlighting.json
@@ -9,6 +9,8 @@
       "title": "Threshold of foreign code coverage for changing the mode in an editor",
       "type": "number",
       "default": 0.5,
+      "minimum": 0,
+      "maximum": 1,
       "description": "If a code editor includes a code fragment in another language (for example a %%markdown magic in IPython) with appropriate foreign code extractor defined, and the extend of this code (coverage of the editor) passes the threshold, the syntax highlighting (i.e. the mode) will change to provide highlighting for the language of the foreign code."
     },
     "disable": {


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes issues with the new Settings Editor introduced in JupyterLab 3.3:

![Screenshot from 2022-03-06 16-15-02](https://user-images.githubusercontent.com/5832902/156931613-1f85a262-0d59-4f90-9362-821e87af6d97.png)

## Code changes

Only JSON settings schema changes.

## User-facing changes

After:

![Screenshot from 2022-03-06 16-18-24](https://user-images.githubusercontent.com/5832902/156931725-757605e3-efcc-468f-93f4-b421bac7e666.png)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [ ] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
