### PR TITLE
Fix tests for JupyterLab 3.3

### DIFF
--- a/atest/03_Notebook.robot
+++ b/atest/03_Notebook.robot
@@ -48,7 +48,7 @@ Moving Cells Around
 Foreign Extractors
     ${file} =    Set Variable    Foreign extractors.ipynb
     Configure JupyterLab Plugin
-    ...    {"language_servers": {"texlab": {"serverSettings": {"latex.lint.onChange": true}}, "bash-langauge-server": {"bashIde.highlightParsingErrors": true}}, "pylsp": {"priority": 1000}}
+    ...    {"language_servers": {"texlab": {"serverSettings": {"chktex.onOpenAndSave": true}}, "bash-langauge-server": {"bashIde.highlightParsingErrors": true}}, "pylsp": {"priority": 1000}}
     Capture Page Screenshot    10-configured.png
     Reset Application State
     Setup Notebook    Python    ${file}

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -83,11 +83,13 @@ Invalidates On Focus Loss
     Enter Cell Editor    1    line=2
 
 Uses LSP Completions When Kernel Resoponse Times Out
+    [Tags]    requires:busy-indicator
     Configure JupyterLab Plugin    {"kernelResponseTimeout": 1, "waitForBusyKernel": true}
     ...    plugin id=${COMPLETION PLUGIN ID}
     Should Complete While Kernel Is Busy
 
 Uses LSP Completions When Kernel Is Busy
+    [Tags]    requires:busy-indicator
     [Documentation]    When kernel is not available the best thing is to show some suggestions (LSP) rather than none.
     Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForBusyKernel": false}
     ...    plugin id=${COMPLETION PLUGIN ID}

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -219,12 +219,12 @@ Kernel And LSP Completions Merge Prefix Conflicts Are Resolved
     Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForBusyKernel": false}
     ...    plugin id=${COMPLETION PLUGIN ID}
     # For more details see: https://github.com/jupyter-lsp/jupyterlab-lsp/issues/30#issuecomment-576003987
-    # `import os.pat<tab>` → `import os.pathsep`
+    # `import os.pat<tab>` → `import os.path`
     Enter Cell Editor    15    line=1
     Trigger Completer
-    Completer Should Suggest    pathsep
-    Select Completer Suggestion    pathsep
-    Wait Until Keyword Succeeds    40x    0.5s    Cell Editor Should Equal    15    import os.pathsep
+    Completer Should Suggest    path
+    Select Completer Suggestion    path
+    Wait Until Keyword Succeeds    40x    0.5s    Cell Editor Should Equal    15    import os.path
 
 Triggers Completer On Dot
     Enter Cell Editor    2    line=1

--- a/atest/07_Configuration.robot
+++ b/atest/07_Configuration.robot
@@ -33,7 +33,7 @@ LaTeX
     [Tags]    language:latex
     ${needs reload} =    Set Variable    "${OS}" == "Windows"
     Settings Should Change Editor Diagnostics    LaTeX    example.tex    texlab
-    ...    {"latex.lint.onChange": true}
+    ...    {"chktex.onOpenAndSave": true}
     ...    ${EMPTY}
     ...    Command terminated with space. (chktex)
     ...    Save File

--- a/atest/Keywords.resource
+++ b/atest/Keywords.resource
@@ -375,7 +375,11 @@ Open File
 
 Open in Advanced Settings
     [Arguments]    ${plugin id}
-    Lab Command    Advanced Settings Editor
+    IF   '${LAB VERSION}'.startswith('3.3')
+      Lab Command    Advanced JSON Settings Editor
+    ELSE
+      Lab Command    Advanced Settings Editor
+    END
     ${sel} =    Set Variable    css:[data-id="${plugin id}"]
     Wait Until Page Contains Element    ${sel}
     Click Element    ${sel}

--- a/binder/overrides.json
+++ b/binder/overrides.json
@@ -8,7 +8,8 @@
       },
       "texlab": {
         "serverSettings": {
-          "latex.lint.onChange": true
+          "chktex.onOpenAndSave": true,
+          "chktex.onEdit": true
         }
       },
       "pyright": {

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/config/texlab.schema.json
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/config/texlab.schema.json
@@ -1,80 +1,80 @@
 {
   "title": "LaTeX configuration",
   "properties": {
-    "latex.rootDirectory": {
+    "rootDirectory": {
       "type": ["string", "null"],
       "default": null,
       "description": "Path to the root directory."
     },
-    "latex.build.executable": {
+    "build.executable": {
       "type": "string",
       "default": "latexmk",
       "description": "Path to a LaTeX build tool."
     },
-    "latex.build.args": {
+    "build.args": {
       "type": "array",
       "default": ["-pdf", "-interaction=nonstopmode", "-synctex=1", "%f"],
       "description": "Additional arguments that are passed to the build tool."
     },
-    "latex.build.onSave": {
+    "build.onSave": {
       "type": "boolean",
       "default": false,
       "description": "Build after saving a file"
     },
-    "latex.build.outputDirectory": {
+    "build.outputDirectory": {
       "type": "string",
       "default": ".",
       "description": "Directory containing the build artifacts."
     },
-    "latex.build.forwardSearchAfter": {
+    "build.forwardSearchAfter": {
       "type": "boolean",
       "default": false,
       "description": "Execute forward search after building"
     },
-    "latex.forwardSearch.executable": {
+    "forwardSearch.executable": {
       "type": ["string", "null"],
       "default": null,
       "description": "Path to a PDF previewer that supports SyncTeX."
     },
-    "latex.forwardSearch.args": {
+    "forwardSearch.args": {
       "type": "array",
       "default": [],
       "description": "Additional arguments that are passed to the previewer."
     },
-    "latex.lint.onSave": {
-      "type": "boolean",
-      "default": true,
-      "description": "Lint after saving a file"
-    },
-    "latex.lint.onChange": {
+    "chktex.onOpenAndSave": {
       "type": "boolean",
       "default": false,
-      "description": "Lint after changing a file"
+      "description": "Lint with chktex after opening and saving a file"
     },
-    "latex.server.autoDownload": {
+    "chktex.onEdit": {
       "type": "boolean",
       "default": false,
-      "description": "Automatically download the language server if it is not installed."
+      "description": "Lint with chktex afte editing a file"
     },
-    "latex.server.trace": {
-      "type": "boolean",
-      "default": false,
-      "description": "Enable the trace verbosity of the server."
+    "diagnosticsDelay": {
+      "type": "integer",
+      "default": 300,
+      "description": "Delay in milliseconds before reporting diagnostics."
     },
-    "latex.server.logFile": {
+    "formatterLineLength": {
+      "type": "integer",
+      "default": 80,
+      "description": "Defines the maximum amount of characters per line (0 = disable) when formatting BibTeX files."
+    },
+    "latexFormatter": {
+      "type": "string",
+      "default": "latexindent",
+      "description": "Defines the formatter to use for LaTeX formatting. Possible values are either texlab or latexindent. Note that texlab is not implemented yet."
+    },
+    "latexindent.local": {
       "type": ["string", "null"],
       "default": null,
-      "description": "Path to the server log file."
+      "description": "Defines the path of a file containing the latexindent configuration. This corresponds to the --local=file.yaml flag of latexindent. By default the configuration inside the project root directory is used."
     },
-    "bibtex.formatting.formatter": {
-      "type": "string",
-      "default": "texlab",
-      "description": "BibTeX formatter to use."
-    },
-    "bibtex.formatting.lineLength": {
-      "type": "integer",
-      "default": 120,
-      "description": "Maximum amount of characters per line (0 = disable)."
+    "latexindent.modifyLineBreaks": {
+      "type": "boolean",
+      "default": false,
+      "description": "Modifies linebreaks before, during, and at the end of code blocks when formatting with latexindent. This corresponds to the --modifylinebreaks flag of latexindent."
     }
   }
 }

--- a/scripts/atest.py
+++ b/scripts/atest.py
@@ -32,6 +32,9 @@ NON_CRITICAL = [
     # TODO: restore once busy indicator is CSS-readable on 3.3.x
     # https://github.com/jupyterlab/jupyterlab/issues/12174
     ["requires:busy-indicator", "lab:3.3.0"],
+    ["requires:busy-indicator", "lab:3.3.1"],
+    ["requires:busy-indicator", "lab:3.3.2"],
+    ["requires:busy-indicator", "lab:3.3.3"],
     # TODO: restore when we figure out win36 vs jedi on windows
     # ["language:python", "py:36", "os:windows"],
 ]

--- a/scripts/atest.py
+++ b/scripts/atest.py
@@ -29,6 +29,9 @@ NON_CRITICAL = [
     # TODO: restore when yaml-language-server supports both config and...
     # everything else: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/245
     ["language:yaml", "feature:config"],
+    # TODO: restore once busy indicator is CSS-readable on 3.3.x
+    # https://github.com/jupyterlab/jupyterlab/issues/12174
+    ["requires:busy-indicator", "lab:3.3.0"],
     # TODO: restore when we figure out win36 vs jedi on windows
     # ["language:python", "py:36", "os:windows"],
 ]


### PR DESCRIPTION
JupyterLab 3.3 uses "Advanced JSON Setting Editor" instead of "Advanced Setting Editor" - should fix some failing tests.

Another change will be needed for JupyterLab 4.0 where it will become just "JSON Setting Editor".

Additionally, updates texlab support (version 3.x).