### PR TITLE
Remove jupyterlab version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Use of a python `virtualenv` or a conda env is also recommended.
 1. install JupyterLab and the extensions
 
    ```bash
-   conda install -c conda-forge 'jupyterlab>=3.0.0,<4.0.0a0' jupyterlab-lsp
+   conda install -c conda-forge jupyterlab-lsp
    # or
-   pip install 'jupyterlab>=3.0.0,<4.0.0a0' jupyterlab-lsp
+   pip install jupyterlab-lsp
    ```
 
    > Note: `jupyterlab-lsp` provides both the server extension and the lab extension.


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

The built artifact on pypi and conda-forge takes care of the version constraints (<4) for jupyterlab. We could probably remove the explicit upper bounds from the user installation bits in the README.

## User-facing changes

A bit more cleaner installation instructions for the user.

Thanks! Let me know if I am missing something here :)
