### PR TITLE
Remove note about language server fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,19 +146,8 @@ Use of a python `virtualenv` or a conda env is also recommended.
    [Microsoft list](https://microsoft.github.io/language-server-protocol/implementors/servers/)
    should work after [some additional configuration](./CONTRIBUTING.md#specs).
 
-   Note 1: it is worth visiting the repository of each server you install as
+   Note: it is worth visiting the repository of each server you install as
    many provide additional configuration options.
-
-   Note 2: we are developing an improved (faster autocompletion, added features)
-   version of the `python-language-server`. It is experimental and should
-   not be used in production yet, but will likely benefit individual users
-   You can check it out with:
-
-   ```bash
-   pip install git+https://github.com/krassowski/python-language-server.git@main
-   ```
-
-   Please report any regressions [here](https://github.com/jupyter-lsp/jupyterlab-lsp/issues/272).
 
 1. Restart JupyterLab
 


### PR DESCRIPTION
My understanding of https://github.com/jupyter-lsp/jupyterlab-lsp/issues/272#issuecomment-891286446 is that these changes how now been merged into the `python-lsp` conda package and there is no need to install the forked language server separately, is this correct? 

Does that mean that the recommended way to install `jupyterlab-lsp` including all the speed-ups is just:

```
conda install jupyterlab-lsp python-lsp-server
```

And there is no need to disable Jedi, since the updates to the pylsp also improved the slow Jedi calls? 

I have some issues with completion speed and can open a ticket with more info, but I just wanted to make sure that I followed the recommended installation procedure first.