### PR TITLE
Increase minimum Node.js to 14.0

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -228,8 +228,8 @@ jobs:
         include:
           # if using 3.7, use newer node, etc...
           - python: '3.7'
-            # Node 12 end-of-life: April 2022
-            nodejs: '>=12,<13.0.0.a0'
+            # Node 14 end-of-life: April 2023
+            nodejs: '>=14,<15.0.0.a0'
             r: '<4'
             lab: '>=3.1.0,<3.2'
           - python: '3.10'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Thank you for all your contributions :heart:
 
 Development requires, at a minimum:
 
-- `nodejs >=12,!=13,!=15,<17`
+- `nodejs >=14,!=15,<17`
 - `python >=3.7,<3.11.0a0`
   - Python 3.7 and 3.10 are fully tested on CI
   - Python 3.7 to 3.10 and PyPy 3 are verified to at least install and import

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - jupyter_server >=1.1.2
   - retrolab >=0.3.0,<0.4
   # build dependencies
-  - nodejs >=12,!=13,!=15,<17
+  - nodejs >=14,!=15,<17
   # for python language server (and development)
   - flake8 >=3.5
   - pip

--- a/docs/rtd.yml
+++ b/docs/rtd.yml
@@ -9,7 +9,7 @@ dependencies:
   - importlib_metadata
   - jupyterlab >=3.1.0,<4.0.0a0
   - myst-nb
-  - nodejs >=12,!=13,!=15,<17
+  - nodejs >=14,!=15,<17
   - pandas
   - pip
   - pytest-check-links


### PR DESCRIPTION
Node 12 reached EOL in April.

Required for bumping of tested servers (in #778) as some dropped support for 12.0 already.