### PR TITLE
Completion/cleanup when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - implement settings UI using native JupyterLab 3.3 UI ([#778])
 - bug fixes
   - use correct websocket URL if configured as different from base URL ([#820], thanks @MikeSem)
+  - clean up all completer styles when compelter feature is disabled ([#829]).
 - refactoring:
   - move client capabilities to features ([#738])
 - documentation:
@@ -26,6 +27,7 @@
 [#814]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/814
 [#820]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/820
 [#826]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/826
+[#829]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/829
 
 ### `@krassowski/jupyterlab-lsp 3.10.1` (2022-03-21)
 

--- a/packages/completion-theme/src/index.ts
+++ b/packages/completion-theme/src/index.ts
@@ -118,7 +118,9 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
       );
     }
     this.current_theme_id = id;
-    document.body.classList.add(this.current_theme_class);
+    if (id !== null) {
+      document.body.classList.add(this.current_theme_class);
+    }
     this.update_icons_set();
   }
 

--- a/packages/completion-theme/style/index.css
+++ b/packages/completion-theme/style/index.css
@@ -24,12 +24,12 @@
   overflow: auto;
 }
 
-.jp-Completer {
+.lsp-completer.jp-Completer {
   --lsp-completer-max-label-width: 300px;
   --lsp-completer-max-detail-width: 200px;
 }
 
-.jp-Completer-match {
+.lsp-completer .jp-Completer-match {
   max-width: var(--lsp-completer-max-label-width);
   overflow-x: hidden;
   white-space: nowrap;
@@ -37,7 +37,7 @@
   text-overflow: ellipsis;
 }
 
-.jp-mod-active .jp-Completer-match {
+.lsp-completer .jp-mod-active .jp-Completer-match {
   text-overflow: clip;
 }
 
@@ -81,7 +81,7 @@ body[data-lsp-completer-layout='detail-below'] .jp-Completer-match {
   height: var(--lsp-completer-label-height);
 }
 
-.jp-Completer-item .jp-Completer-typeExtended {
+.lsp-completer .jp-Completer-item .jp-Completer-typeExtended {
   max-width: var(--lsp-completer-max-detail-width);
   min-height: 50px;
   overflow-x: hidden;
@@ -89,7 +89,7 @@ body[data-lsp-completer-layout='detail-below'] .jp-Completer-match {
   white-space: nowrap;
 }
 
-.jp-mod-active .jp-Completer-typeExtended {
+.lsp-completer .jp-mod-active .jp-Completer-typeExtended {
   text-overflow: clip;
 }
 

--- a/packages/completion-theme/style/index.css
+++ b/packages/completion-theme/style/index.css
@@ -20,7 +20,7 @@
 /* a workaround for scrollbars being always on in the completer documentation panel, see
  https://github.com/jupyter-lsp/jupyterlab-lsp/pull/322#issuecomment-682724175
  */
-.jp-Completer-docpanel {
+.lsp-completer .jp-Completer-docpanel {
   overflow: auto;
 }
 
@@ -47,7 +47,7 @@
 }
 
 /* a workaround for code being larger font size than text in markdown-rendered panel */
-.jp-Completer-docpanel pre code {
+.lsp-completer .jp-Completer-docpanel pre code {
   font-size: 90%;
 }
 

--- a/packages/jupyterlab-lsp/src/features/completion/completion.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion.ts
@@ -1,6 +1,10 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import { CompletionHandler, ICompletionManager } from '@jupyterlab/completer';
+import {
+  CompletionHandler,
+  ICompletionManager,
+  CompleterModel
+} from '@jupyterlab/completer';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { NotebookPanel } from '@jupyterlab/notebook';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
@@ -27,6 +31,7 @@ import { ICompletionData, LSPCompletionRenderer } from './renderer';
 
 const DOC_PANEL_SELECTOR = '.jp-Completer-docpanel';
 const DOC_PANEL_PLACEHOLDER_CLASS = 'lsp-completer-placeholder';
+const LSP_COMPLETER_CLASS = 'lsp-completer';
 
 export class CompletionCM extends CodeMirrorIntegration {
   private _completionCharacters: string[];
@@ -89,6 +94,7 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
   protected renderer: LSPCompletionRenderer;
   private _latestActiveItem: LazyCompletionItem | null = null;
   private _signalConnected: boolean = false;
+  private _disabled: boolean;
 
   constructor(
     private app: JupyterFrontEnd,
@@ -110,16 +116,20 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
     this.renderer.activeChanged.connect(this.active_completion_changed, this);
     this.renderer.itemShown.connect(this.resolve_and_update, this);
     this._signalConnected = false;
+    this._disabled = false;
     // TODO: figure out a better way to disable lab integration elements (postpone initialization?)
     settings.ready
       .then(() => {
+        this._disabled = settings.composite.disable;
         if (!settings.composite.disable) {
           adapterManager.adapterChanged.connect(this.swap_adapter, this);
           this._signalConnected = true;
         }
       })
       .catch(console.warn);
+
     settings.changed.connect(() => {
+      this._disabled = settings.composite.disable;
       if (!settings.composite.disable) {
         document.body.dataset.lspCompleterLayout =
           this.settings.composite.layout;
@@ -131,16 +141,14 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
           adapterManager.adapterChanged.connect(this.swap_adapter, this);
           this._signalConnected = true;
         }
-        // TODO connect adapter if not connected
       } else {
         completionThemeManager.set_theme(null);
         delete document.body.dataset.lspCompleterLayout;
-        if (this._signalConnected) {
-          adapterManager.adapterChanged.disconnect(this.swap_adapter, this);
-          this._signalConnected = false;
-        }
       }
-      if (this.current_completion_handler) {
+      if (
+        this.current_completion_handler &&
+        this.model instanceof LSPCompleterModel
+      ) {
         this.model.settings.caseSensitive =
           this.settings.composite.caseSensitive;
         this.model.settings.includePerfectMatches =
@@ -299,12 +307,17 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
       this.renderer
     ) as CompletionHandler;
     let completer = this.completer;
-    completer.addClass('lsp-completer');
-    completer.model = new LSPCompleterModel({
-      caseSensitive: this.settings.composite.caseSensitive,
-      includePerfectMatches: this.settings.composite.includePerfectMatches,
-      preFilterMatches: this.settings.composite.preFilterMatches
-    });
+    if (this._disabled) {
+      completer.removeClass(LSP_COMPLETER_CLASS);
+      completer.model = new CompleterModel();
+    } else {
+      completer.addClass(LSP_COMPLETER_CLASS);
+      completer.model = new LSPCompleterModel({
+        caseSensitive: this.settings.composite.caseSensitive,
+        includePerfectMatches: this.settings.composite.includePerfectMatches,
+        preFilterMatches: this.settings.composite.preFilterMatches
+      });
+    }
   }
 
   protected get completer() {
@@ -312,8 +325,8 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
     return this.current_completion_handler.completer;
   }
 
-  protected get model(): LSPCompleterModel {
-    return this.completer.model as LSPCompleterModel;
+  protected get model(): LSPCompleterModel | CompleterModel {
+    return this.completer.model as LSPCompleterModel | CompleterModel;
   }
 
   invoke_completer(kind: ExtendedCompletionTriggerKind) {
@@ -351,6 +364,9 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
   private get current_items() {
     // TODO upstream: allow to get completionItems() without markup
     //   (note: not trivial as _markup() does filtering too)
+    if (!(this.model instanceof LSPCompleterModel)) {
+      return [];
+    }
     return this.model.completionItems();
   }
 


### PR DESCRIPTION
## References

Clean up all completer styles when disabling (noticed in https://github.com/jupyterlab/jupyterlab/issues/12830).

## Code changes

- Increase specificity of styles by adding `.lsp-completer` as needed
- when completer gets disabled
  - remove completion theme class from body
  - remove completer layout data from body
  - use upstream model for completion data (although refresh is still needed to rewire data connection) 

## User-facing changes

- styles should no longer spill when LSP completer is disabled via settings
- after re-enabling styles are restored and LSP completer works without a refresh (refresh is still needed to fully disable it, see note in "code changes").

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
