### PR TITLE
Fix LSP completion transform of path-likes when `insertText` missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   - implement settings UI using native JupyterLab 3.3 UI ([#778])
 - bug fixes
   - use correct websocket URL if configured as different from base URL ([#820], thanks @MikeSem)
-  - clean up all completer styles when compelter feature is disabled ([#829]).
+  - clean up all completer styles when completer feature is disabled ([#829]).
+  - fix `undefined` being inserted for path-like completion items with no `insertText` ([#833])
 - refactoring:
   - move client capabilities to features ([#738])
 - documentation:
@@ -28,6 +29,7 @@
 [#820]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/820
 [#826]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/826
 [#829]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/829
+[#833]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/833
 
 ### `@krassowski/jupyterlab-lsp 3.10.1` (2022-03-21)
 

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.spec.ts
@@ -1,0 +1,87 @@
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { expect } from 'chai';
+import type * as lsProtocol from 'vscode-languageserver-types';
+
+import { BrowserConsole } from '../../virtual/console';
+
+import { transformLSPCompletions } from './completion_handler';
+
+describe('transformLSPCompletions', () => {
+  const browserConsole = new BrowserConsole();
+
+  const transform = (
+    token: CodeEditor.IToken,
+    position: number,
+    completions: lsProtocol.CompletionItem[]
+  ) => {
+    return transformLSPCompletions(
+      token,
+      position,
+      completions,
+      (kind: string, match: lsProtocol.CompletionItem) => {
+        return { kind, match };
+      },
+      browserConsole
+    );
+  };
+
+  it('Harmonizes `insertText` from `undefined` when adjusting path-like completions', () => {
+    // `import { } from '@lumino/<TAB>'`
+    const result = transform(
+      {
+        offset: 16,
+        value: "'@lumino/'",
+        type: 'string'
+      },
+      8,
+      [
+        {
+          label: 'algorithm',
+          kind: 19,
+          sortText: '1',
+          data: {
+            entryNames: ['algorithm']
+          }
+        },
+        {
+          label: 'application',
+          kind: 19,
+          sortText: '1',
+          data: {
+            entryNames: ['application']
+          }
+        }
+      ]
+    );
+    expect(result.items.length).to.equal(2);
+    // insert text should keep `'` as it was part of original token
+    expect(result.items[0].match.insertText).to.equal("'@lumino/algorithm");
+    // label should not include `'`
+    expect(result.items[0].match.label).to.equal('@lumino/algorithm');
+    expect(result.source).to.equal('LSP');
+  });
+
+  it('Harmonizes `insertText` for paths', () => {
+    // `'./Hov`
+    const result = transform(
+      {
+        offset: 0,
+        value: "'./Hov",
+        type: 'string'
+      },
+      5,
+      [
+        {
+          label: "Hover.ipynb'",
+          kind: 17,
+          sortText: "aHover.ipynb'",
+          insertText: "Hover.ipynb'"
+        }
+      ]
+    );
+    // insert text should keep `'` as it was part of original token
+    expect(result.items[0].match.insertText).to.equal("'./Hover.ipynb'");
+    // label should not include initial `'`
+    expect(result.items[0].match.label).to.equal("./Hover.ipynb'");
+  });
+});

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.spec.ts
@@ -58,7 +58,7 @@ describe('transformLSPCompletions', () => {
     expect(result.items[0].match.insertText).to.equal("'@lumino/algorithm");
     // label should not include `'`
     expect(result.items[0].match.label).to.equal('@lumino/algorithm');
-    expect(result.source).to.equal('LSP');
+    expect(result.source.name).to.equal('LSP');
   });
 
   it('Harmonizes `insertText` for paths', () => {


### PR DESCRIPTION
## References

Fixes #832

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Completion of `import { Signal } from @lumino/<tab>` will work correctly.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
