### PR TITLE
Reduce signature and hover flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - use correct websocket URL if configured as different from base URL ([#820], thanks @MikeSem)
   - clean up all completer styles when completer feature is disabled ([#829]).
   - fix `undefined` being inserted for path-like completion items with no `insertText` ([#833])
-  - reduce signature flickering when typing ([#836])
+  - reduce signature flickering when typing and hover flicker when moving mouse ([#836])
 - refactoring:
   - move client capabilities to features ([#738])
 - documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - use correct websocket URL if configured as different from base URL ([#820], thanks @MikeSem)
   - clean up all completer styles when completer feature is disabled ([#829]).
   - fix `undefined` being inserted for path-like completion items with no `insertText` ([#833])
+  - reduce signature flickering when typing ([#836])
 - refactoring:
   - move client capabilities to features ([#738])
 - documentation:
@@ -30,6 +31,7 @@
 [#826]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/826
 [#829]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/829
 [#833]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/833
+[#836]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/836
 
 ### `@krassowski/jupyterlab-lsp 3.10.1` (2022-03-21)
 

--- a/atest/05_Features/Signature.robot
+++ b/atest/05_Features/Signature.robot
@@ -18,11 +18,12 @@ ${SIGNATURE_DETAILS}            css:${SIGNATURE_DETAILS_CSS}
 
 *** Test Cases ***
 Triggers Signature Help After A Keystroke
-    Enter Cell Editor    1    line=6
+    Enter Cell Editor    2    line=6
     Capture Page Screenshot    01-entered-cell.png
     Press Keys    None    (
     Capture Page Screenshot    02-signature-shown.png
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
+    Element Should Be Visible    ${SIGNATURE_BOX}
     Wait Until Keyword Succeeds    10x    0.5s    Element Should Contain    ${SIGNATURE_BOX}
     ...    Important docstring of abc()
     Element Should Contain    ${SIGNATURE_HIGHLIGHTED_ARG}    x
@@ -40,25 +41,40 @@ Triggers Signature Help After A Keystroke
     Press Keys    None    )
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Not Contain Element    ${SIGNATURE_BOX}
 
+
+Triggered Signature Is Visible In First Cell
+    # test boundary conditions for out of view behaviour
+    Enter Cell Editor    1
+    Press Keys    None    (
+    Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
+    Element Should Be Visible    ${SIGNATURE_BOX}
+
+
 Should Close After Moving Cursor Prior To Start
-    Enter Cell Editor    1    line=6
+    Enter Cell Editor    2    line=6
     Press Keys    None    (
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
     Press Keys    None    LEFT
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Not Contain Element    ${SIGNATURE_BOX}
+    # retrigger
+    Press Keys    None    DELETE
+    Press Keys    None    (
+    Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
+    Press Keys    None    UP
+    Wait Until Keyword Succeeds    20x    0.5s    Page Should Not Contain Element    ${SIGNATURE_BOX}
 
 Should Close After Executing The Cell
-    Enter Cell Editor    1    line=6
+    Enter Cell Editor    2    line=6
     Press Keys    None    (
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
     Press Keys    None    SHIFT+ENTER
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Not Contain Element    ${SIGNATURE_BOX}
 
 Invalidates On Cell Change
-    Enter Cell Editor    1    line=6
+    Enter Cell Editor    2    line=6
     Press Keys    None    (
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
-    Enter Cell Editor    2
+    Enter Cell Editor    1
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Not Contain Element    ${SIGNATURE_BOX}
 
 Details Should Expand On Click
@@ -66,6 +82,7 @@ Details Should Expand On Click
     Enter Cell Editor    3    line=11
     Press Keys    None    (
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
+    Element Should Be Visible    ${SIGNATURE_BOX}
     Wait Until Keyword Succeeds    10x    0.5s    Element Should Contain    ${SIGNATURE_BOX}    Short description.
     Page Should Contain Element    ${SIGNATURE_DETAILS}
     Details Should Be Collapsed    ${SIGNATURE_DETAILS_CSS}

--- a/atest/examples/Signature.ipynb
+++ b/atest/examples/Signature.ipynb
@@ -3,6 +3,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -17,15 +26,6 @@
     "\n",
     "\n",
     "abc"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "list"
    ]
   },
   {

--- a/packages/jupyterlab-lsp/src/components/free_tooltip.ts
+++ b/packages/jupyterlab-lsp/src/components/free_tooltip.ts
@@ -159,7 +159,16 @@ export class FreeTooltip extends Tooltip {
       node: this.node,
       offset: { horizontal: -1 * paddingLeft },
       privilege: this.options.privilege || 'below',
-      style: style
+      style: style,
+      // TODO: remove `ts-ignore` once minimum version is >=3.5
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      outOfViewDisplay: {
+        left: 'stick-inside',
+        right: 'stick-outside',
+        top: 'stick-outside',
+        bottom: 'stick-inside'
+      }
     });
   }
 }

--- a/packages/jupyterlab-lsp/src/components/free_tooltip.ts
+++ b/packages/jupyterlab-lsp/src/components/free_tooltip.ts
@@ -206,6 +206,7 @@ export class EditorTooltipManager {
   showOrCreate(options: EditorTooltip.IOptions) {
     if (
       this.currentTooltip !== null &&
+      !this.currentTooltip.isDisposed &&
       this.currentOptions &&
       this.currentOptions.adapter === options.adapter &&
       is_equal(this.currentOptions.position, options.position) &&

--- a/packages/jupyterlab-lsp/src/components/free_tooltip.ts
+++ b/packages/jupyterlab-lsp/src/components/free_tooltip.ts
@@ -15,7 +15,7 @@ import * as lsProtocol from 'vscode-languageserver-protocol';
 
 import { WidgetAdapter } from '../adapters/adapter';
 import { PositionConverter } from '../converter';
-import { IEditorPosition } from '../positioning';
+import { IEditorPosition, is_equal } from '../positioning';
 
 const MIN_HEIGHT = 20;
 const MAX_HEIGHT = 250;
@@ -196,6 +196,21 @@ export class EditorTooltipManager {
     return tooltip;
   }
 
+  showOrCreate(options: EditorTooltip.IOptions) {
+    if (
+      this.currentTooltip !== null &&
+      this.currentOptions &&
+      this.currentOptions.markup.value === options.markup.value &&
+      this.currentOptions.adapter === options.adapter &&
+      is_equal(this.currentOptions.position, options.position) &&
+      this.currentOptions.id === options.id
+    ) {
+      this.show();
+    } else {
+      this.create(options);
+    }
+  }
+
   get position(): IEditorPosition {
     return this.currentOptions!.position;
   }
@@ -209,6 +224,18 @@ export class EditorTooltipManager {
       !this.currentTooltip.isDisposed &&
       this.currentTooltip.isVisible
     );
+  }
+
+  hide() {
+    if (this.currentTooltip !== null) {
+      this.currentTooltip.hide();
+    }
+  }
+
+  show() {
+    if (this.currentTooltip !== null) {
+      this.currentTooltip.show();
+    }
   }
 
   remove() {

--- a/packages/jupyterlab-lsp/src/components/free_tooltip.ts
+++ b/packages/jupyterlab-lsp/src/components/free_tooltip.ts
@@ -222,6 +222,7 @@ export class EditorTooltipManager {
         this.show();
       }
     } else {
+      this.remove();
       this.create(options);
     }
   }

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -342,12 +342,11 @@ export class HoverCM extends CodeMirrorIntegration {
     this.last_hover_response = response;
 
     if (show_tooltip) {
-      this.lab_integration.tooltip.remove();
       const markup = HoverCM.get_markup_for_hover(response);
       let editor_position =
         this.virtual_editor.root_position_to_editor(root_position);
 
-      this.tooltip = this.lab_integration.tooltip.create({
+      this.tooltip = this.lab_integration.tooltip.showOrCreate({
         markup,
         position: editor_position,
         ce_editor: response_data.ce_editor,

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -184,7 +184,7 @@ export class SignatureCM extends CodeMirrorIntegration {
       this.isSignatureShown() &&
       (event.relatedTarget as Element).closest('.' + CLASS_NAME) === null
     ) {
-      this._hideTooltip();
+      this._removeTooltip();
     }
   }
 
@@ -201,7 +201,7 @@ export class SignatureCM extends CodeMirrorIntegration {
       newEditorPosition.line === previousPosition.line &&
       newEditorPosition.ch < previousPosition.ch
     ) {
-      this._hideTooltip();
+      this._removeTooltip();
     } else {
       // otherwise, update the signature as the active parameter could have changed,
       // or the server may want us to close the tooltip
@@ -297,8 +297,12 @@ export class SignatureCM extends CodeMirrorIntegration {
     );
   }
 
-  private _hideTooltip() {
+  private _removeTooltip() {
     this.lab_integration.tooltip.remove();
+  }
+
+  private _hideTooltip() {
+    this.lab_integration.tooltip.hide();
   }
 
   private handleSignature(
@@ -307,13 +311,18 @@ export class SignatureCM extends CodeMirrorIntegration {
     display_position: IEditorPosition | null = null
   ) {
     this.console.log('Signature received', response);
-    if (response || response === null) {
+    if (response === null) {
       // do not hide on undefined as it simply indicates that no new info is available
       // (null means close, response means update)
+      this._removeTooltip();
+    } else if (response) {
       this._hideTooltip();
     }
 
     if (!this.signatureCharacter || !response || !response.signatures.length) {
+      if (response) {
+        this._removeTooltip();
+      }
       this.console.debug(
         'Ignoring signature response: cursor lost or response empty'
       );
@@ -353,7 +362,7 @@ export class SignatureCM extends CodeMirrorIntegration {
       response
     );
 
-    this.lab_integration.tooltip.create({
+    this.lab_integration.tooltip.showOrCreate({
       markup,
       position: display_position === null ? editor_position : display_position,
       id: TOOLTIP_ID,
@@ -390,7 +399,7 @@ export class SignatureCM extends CodeMirrorIntegration {
       previousPosition = this.lab_integration.tooltip.position;
       if (this._closeCharacters.includes(last_character)) {
         // remove just in case but do not short-circuit in case if we need to re-trigger
-        this._hideTooltip();
+        this._removeTooltip();
       }
     }
 

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -201,7 +201,11 @@ export class SignatureCM extends CodeMirrorIntegration {
       newEditorPosition.line === previousPosition.line &&
       newEditorPosition.ch < previousPosition.ch
     ) {
-      this._removeTooltip();
+      // hide (not remove) since there is a chance the user is just
+      // typing the signature at the end of line which means that
+      // they will likelly get a signature reply again, and then
+      // re-using existing tooltip gives smoother experience.
+      this._hideTooltip();
     } else {
       // otherwise, update the signature as the active parameter could have changed,
       // or the server may want us to close the tooltip


### PR DESCRIPTION
## References

Fixes #834

## Code changes

`EditorTooltipManager` gest new methods: `showOrCreate`, `show`, `hide`

## User-facing changes


Signature tooltip will be hidden (rather than removed) if we know that we will be showing it again soon; if it has not changed (nor position, editor, etc), it will be shown as-is, if only content changed it will be updated.

Unfortunately, pylsp seems to return a message with empty signature every other time which is the direct cause of flickering in remaining instances.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
