### PR TITLE
Explore how to implement `isIncomplete` support

### DIFF
--- a/packages/jupyterlab-lsp/src/connection.ts
+++ b/packages/jupyterlab-lsp/src/connection.ts
@@ -4,8 +4,6 @@
 // Introduced modifications are BSD licenced, copyright JupyterLab development team.
 import { ISignal, Signal } from '@lumino/signaling';
 import {
-  AnyCompletion,
-  AnyLocation,
   IDocumentInfo,
   ILspOptions,
   IPosition,
@@ -19,7 +17,7 @@ import type * as rpc from 'vscode-jsonrpc';
 import type * as lsp from 'vscode-languageserver-protocol';
 import type { MessageConnection } from 'vscode-ws-jsonrpc';
 
-import { ClientCapabilities } from './lsp';
+import { AnyLocation, AnyCompletion, ClientCapabilities } from './lsp';
 import { ILSPLogConsole } from './tokens';
 import { until_ready } from './utils';
 

--- a/packages/jupyterlab-lsp/src/features/completion/completion.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion.ts
@@ -312,11 +312,45 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
       completer.model = new CompleterModel();
     } else {
       completer.addClass(LSP_COMPLETER_CLASS);
-      completer.model = new LSPCompleterModel({
+      const model = new LSPCompleterModel({
         caseSensitive: this.settings.composite.caseSensitive,
         includePerfectMatches: this.settings.composite.includePerfectMatches,
         preFilterMatches: this.settings.composite.preFilterMatches
       });
+      completer.model = model;
+      model.queryChanged.connect(this._handleQuery.bind(this));
+      // TODO: disconnect!
+    }
+  }
+
+  /**
+   * User typed a character while the completer is shown changing the query.
+   */
+  private async _handleQuery(model: LSPCompleterModel, query: string) {
+    // it is important not to fail here: otherwise we break native completer too.
+    try {
+      if (!this.current_completion_connector.isIncomplete) {
+        // do nothing if the result was complete
+        return;
+      } else if(!this.current_adapter) {
+        return;
+      } else {
+        // TODO: can we only fetch LSP items, keep kernel items as-is?
+        await this.current_adapter.update_documents();
+        const reply = await this.current_completion_connector.fetch();
+        if (reply) {
+          model.query = ''
+          // ref `CompletionHandler._updateModel`
+          model.cursor = {
+            start: reply.start, // should be wrapped in `Text.charIndexToJsIndex(start, text)`,
+            end: reply.end
+          }
+          model.original = model.current;
+          model.setCompletionItems(reply.items as LazyCompletionItem[]);
+        }
+      }
+    } catch(e) {
+      this.console.error('handling query change failed', e);
     }
   }
 

--- a/packages/jupyterlab-lsp/src/lsp.ts
+++ b/packages/jupyterlab-lsp/src/lsp.ts
@@ -13,6 +13,18 @@ export enum DiagnosticSeverity {
   Hint = 4
 }
 
+
+export type AnyLocation =
+  | lsp.Location
+  | lsp.Location[]
+  | lsp.LocationLink[]
+  | undefined
+  | null;
+
+export type AnyCompletion =
+  | lsp.CompletionList
+  | lsp.CompletionItem[];
+
 export enum DiagnosticTag {
   Unnecessary = 1,
   Deprecated = 2

--- a/packages/lsp-ws-connection/src/types.ts
+++ b/packages/lsp-ws-connection/src/types.ts
@@ -18,6 +18,10 @@ export interface IDocumentInfo {
   languageId: string;
 }
 
+/**
+ * @deprecated, moved to `@jupyter-lsp/jupyterlab-lsp/lsp.ts`
+ * (will become `@jupyterlab/lsp/lsp.ts` in near futurue)
+ */
 export type AnyLocation =
   | lsProtocol.Location
   | lsProtocol.Location[]
@@ -25,9 +29,14 @@ export type AnyLocation =
   | undefined
   | null;
 
+/**
+ * @deprecated, moved to `@jupyter-lsp/jupyterlab-lsp/lsp.ts`
+ * (will become `@jupyterlab/lsp/lsp.ts` in near futurue)
+ */
 export type AnyCompletion =
   | lsProtocol.CompletionList
   | lsProtocol.CompletionItem[];
+
 
 export enum CompletionTriggerKind {
   Invoked = 1,


### PR DESCRIPTION
## References

Partially fixes #776 but does not work reliably; instead an implementation upstream in JupyterLab is needed. We need to think how to add this. Supporting `isIncomplete` is needed because:
- it enables faster completions when latency between server is low
- it is a non-optional part of LSP spec
- servers like TexLab and R server depend on it for completions

Not sure if i will be merging this one (not happy with how non-reliably this works), unless I can fix it without relying on extensive changes upstream.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [ ] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
