### PR TITLE
Improve performance of diagnostics and highlights

### DIFF
--- a/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
@@ -245,6 +245,9 @@ export abstract class CodeMirrorIntegration
     }
   }
 
+  /**
+   * @deprecated
+   */
   protected highlight_range(
     range: IEditorRange,
     class_name: string

--- a/packages/jupyterlab-lsp/src/features/highlights.ts
+++ b/packages/jupyterlab-lsp/src/features/highlights.ts
@@ -14,7 +14,11 @@ import { CodeHighlights as LSPHighlightsSettings } from '../_highlights';
 import { CodeMirrorIntegration } from '../editor_integration/codemirror';
 import { FeatureSettings } from '../feature';
 import { DocumentHighlightKind } from '../lsp';
-import { IRootPosition, IVirtualPosition } from '../positioning';
+import {
+  IEditorPosition,
+  IRootPosition,
+  IVirtualPosition
+} from '../positioning';
 import { ILSPFeatureManager, PLUGIN_ID } from '../tokens';
 import { VirtualDocument } from '../virtual/document';
 
@@ -23,8 +27,19 @@ export const highlightIcon = new LabIcon({
   svgstr: highlightSvg
 });
 
+interface IHighlightDefinition {
+  options: CodeMirror.TextMarkerOptions;
+  start: IEditorPosition;
+  end: IEditorPosition;
+}
+
 export class HighlightsCM extends CodeMirrorIntegration {
-  protected highlight_markers: CodeMirror.TextMarker[] = [];
+  protected highlightMarkers: Map<CodeMirror.Editor, CodeMirror.TextMarker[]> =
+    new Map();
+  /*
+   * @deprecated
+   */
+  protected highlight_markers: CodeMirror.TextMarker[];
   private debounced_get_highlight: Debouncer<
     lsProtocol.DocumentHighlight[] | undefined
   >;
@@ -63,9 +78,14 @@ export class HighlightsCM extends CodeMirrorIntegration {
   }
 
   protected clear_markers() {
-    for (let marker of this.highlight_markers) {
-      marker.clear();
+    for (const [cmEditor, markers] of this.highlightMarkers.entries()) {
+      cmEditor.operation(() => {
+        for (const marker of markers) {
+          marker.clear();
+        }
+      });
     }
+    this.highlightMarkers = new Map();
     this.highlight_markers = [];
   }
 
@@ -78,16 +98,75 @@ export class HighlightsCM extends CodeMirrorIntegration {
       return;
     }
 
+    const highlightOptionsByEditor = new Map<
+      CodeMirror.Editor,
+      IHighlightDefinition[]
+    >();
+
     for (let item of items) {
       let range = this.range_to_editor_range(item.range);
       let kind_class = item.kind
         ? 'cm-lsp-highlight-' + DocumentHighlightKind[item.kind]
         : '';
-      let marker = this.highlight_range(
-        range,
-        'cm-lsp-highlight ' + kind_class
-      );
-      this.highlight_markers.push(marker);
+
+      let optionsList = highlightOptionsByEditor.get(range.editor);
+
+      if (!optionsList) {
+        optionsList = [];
+        highlightOptionsByEditor.set(range.editor, optionsList);
+      }
+      optionsList.push({
+        options: {
+          className: 'cm-lsp-highlight ' + kind_class
+        },
+        start: range.start,
+        end: range.end
+      });
+    }
+
+    for (const [
+      cmEditor,
+      markerDefinitions
+    ] of highlightOptionsByEditor.entries()) {
+      // note: using `operation()` significantly improves performance.
+      // test cases:
+      //   - one cell with 1000 `math.pi` and `import math`; move cursor to `math`,
+      //     wait for 1000 highlights, then move to `pi`:
+      //     - before:
+      //        - highlight `math`: 13.1s
+      //        - then highlight `pi`: 16.6s
+      //     - after:
+      //        - highlight `math`: 160ms
+      //        - then highlight `pi`: 227ms
+      //   - 100 cells with `math.pi` and one with `import math`; move cursor to `math`,
+      //     wait for 1000 highlights, then move to `pi` (this is overhead control,
+      //     no gains expected):
+      //     - before:
+      //        - highlight `math`: 385ms
+      //        - then highlight `pi`: 683 ms
+      //     - after:
+      //        - highlight `math`: 390ms
+      //        - then highlight `pi`: 870ms
+      cmEditor.operation(() => {
+        const doc = cmEditor.getDoc();
+        const markersList: CodeMirror.TextMarker[] = [];
+        for (const definition of markerDefinitions) {
+          let marker;
+          try {
+            marker = doc.markText(
+              definition.start,
+              definition.end,
+              definition.options
+            );
+          } catch (e) {
+            this.console.warn('Marking highlight failed:', definition, e);
+            return;
+          }
+          markersList.push(marker);
+          this.highlight_markers.push(marker);
+        }
+        this.highlightMarkers.set(cmEditor, markersList);
+      });
     }
   };
 


### PR DESCRIPTION
## Code changes

- Use `.operation()` for setting CodeMirror5 marks; should also help with porting to CM6 (where `RangeSets` will take over some of the responsibility)
- deprecate `highlight_range` and `highlight_markers` protected properties.

## User-facing changes

Improved performance when more than one diagnostic of highlighted element present in editor; especially noticeable in notebooks as the cost of relayout there is much higher, but also noticeable in file editor for large scripts.

### Highlights
- one cell with 1000 `math.pi` and `import math`; move cursor to `math`, wait for 1000 highlights, then move to `pi`:
  - before:
     - highlight `math`: 13.1s
     - then highlight `pi`: 16.6s
  - after:
      - highlight `math`: 160ms
       then highlight `pi`: 227ms
- 100 cells with `math.pi` and one with `import math`; move cursor to `math`, wait for 1000 highlights, then move to `pi` (this is overhead control, no gains expected):
   - before:
       - highlight `math`: 385ms
       - then highlight `pi`: 683 ms
    - after:
       - highlight `math`: 390ms
      - then highlight `pi`: 870ms

### Diagnostics

- one cell with 1000 `math.pi` and `import math`; comment out import, wait for 1000 diagnostics, then uncomment import, wait for removal:
  - before:
     - diagnostics show up in: 13.6s (blocking!)
     - diagnostics removal in: 13.2s (blocking!)
  - after:
     - diagnostics show up in: 254ms
     - diagnostics removal in: 160.4ms
- first open of a notebook with 10 cells, each with 88 diagnostics:
  - before: 2.75s (each time)
  - after 208.75ms
- first open of a notebook with 100 cells, each with 1 diagnostic this scenario is expected to have no gain (measures overhead)
  - before 280.34ms, 377ms, 399ms
  - after 385.29ms, 301.97ms, 309.4ms 

## Backwards-incompatible changes

None.

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
