### PR TITLE
Allow to pass default workspace config (`serverSettings`) in specs

### DIFF
--- a/atest/07_Configuration.robot
+++ b/atest/07_Configuration.robot
@@ -16,6 +16,15 @@ Python
     ...    undefined name 'foo' (pyflakes)
     ...    undefined name 'foo' (flake8)
 
+Python (programmatically)
+    [Documentation]    same as "Python" but changing the defaults in server specification via `workspace_configuration`
+    Settings Should Change Editor Diagnostics    Python    style.py    pylsp-with-config-override
+    ...    settings=100
+    ...    before=undefined name 'foo' (pyflakes)
+    ...    after=undefined name 'foo' (flake8)
+    ...    setting_key=priority
+    ...    needs reload=${True}
+
 YAML
     [Documentation]    Composer YAML files don't allow a "greetings" key
     Settings Should Change Editor Diagnostics    YAML    example.yaml    yaml-language-server
@@ -47,7 +56,7 @@ LaTeX
 
 *** Keywords ***
 Settings Should Change Editor Diagnostics
-    [Arguments]    ${language}    ${file}    ${server}    ${settings}    ${before}    ${after}    ${save command}=${EMPTY}    ${needs reload}=${False}
+    [Arguments]    ${language}    ${file}    ${server}    ${settings}    ${before}    ${after}    ${save command}=${EMPTY}    ${needs reload}=${False}    ${setting_key}=serverSettings
     ${before diagnostic} =    Set Variable    ${CSS DIAGNOSTIC}\[title*="${before}"]
     ${after diagnostic} =    Set Variable    ${CSS DIAGNOSTIC}\[title*="${after}"]
     ${tab} =    Set Variable    ${JLAB XP DOCK TAB}\[contains(., '${file}')]
@@ -65,7 +74,7 @@ Settings Should Change Editor Diagnostics
     END
     Page Should Not Contain    ${after diagnostic}
     Capture Page Screenshot    01-default-diagnostics-and-settings.png
-    Set Editor Content    {"language_servers": {"${server}": {"serverSettings": ${settings}}}}    ${CSS USER SETTINGS}
+    Set Editor Content    {"language_servers": {"${server}": {"${setting_key}": ${settings}}}}    ${CSS USER SETTINGS}
     Wait Until Page Contains    No errors found
     Capture Page Screenshot    02-default-diagnostics-and-unsaved-settings.png
     Click Element    css:button[title^\='Save User Settings']

--- a/atest/Keywords.resource
+++ b/atest/Keywords.resource
@@ -40,12 +40,14 @@ Initialize Global Variables
 Create Notebok Server Config
     [Documentation]    Copies in notebook server config file and updates accordingly
     [Arguments]    ${server_extension_enabled}=${True}
-    ${conf} =    Set Variable    ${NOTEBOOK DIR}${/}${NBSERVER CONF}
+    ${conf} =    Set Variable    ${NOTEBOOK DIR}${/}${JPSERVER CONF JSON}
     ${extra_node_roots} =    Create List    ${ROOT}
     ${port} =    Get Unused Port
     Set Global Variable    ${PORT}    ${port}
     Set Global Variable    ${URL}    http://localhost:${PORT}${BASE URL}
-    Copy File    ${FIXTURES}${/}${NBSERVER CONF}    ${conf}
+    Copy File    ${FIXTURES}${/}${JPSERVER CONF JSON}    ${conf}
+    Copy File    ${FIXTURES}${/}${JPSERVER CONF PY}    ${NOTEBOOK DIR}${/}${JPSERVER CONF PY}
+    Copy File    ${FIXTURES}${/}overrides.json    ${NOTEBOOK DIR}${/}overrides.json
     Update Jupyter Config    ${conf}    ServerApp
     ...    base_url=${BASE URL}
     ...    port=${PORT}

--- a/atest/Variables.resource
+++ b/atest/Variables.resource
@@ -1,6 +1,7 @@
 *** Variables ***
 ${FIXTURES}                     ${CURDIR}${/}fixtures
-${NBSERVER CONF}                jupyter_server_config.json
+${JPSERVER CONF JSON}           jupyter_server_config.json
+${JPSERVER CONF PY}             jupyter_server_config.py
 ${SPLASH}                       id:jupyterlab-splash
 # to help catch hard-coded paths and encoding issues
 ${BASE URL}                     /@est/

--- a/atest/fixtures/jupyter_server_config.json
+++ b/atest/fixtures/jupyter_server_config.json
@@ -7,7 +7,10 @@
     "tornado_settings": {
       "page_config_data": {
         "buildCheck": false,
-        "buildAvailable": false
+        "buildAvailable": false,
+        "disabledExtensions": {
+          "jupyterlab-unfold": true
+        }
       }
     }
   }

--- a/atest/fixtures/jupyter_server_config.py
+++ b/atest/fixtures/jupyter_server_config.py
@@ -1,0 +1,18 @@
+from jupyter_lsp.specs.python_lsp_server import PythonLSPServer
+from jupyter_lsp.types import LanguageServerManagerAPI
+
+
+manager: LanguageServerManagerAPI = None   # type: ignore
+pylsp_base: dict = PythonLSPServer()(manager)
+
+
+c.LanguageServerManager.language_servers.update({
+    "pylsp-with-config-override": {
+        **pylsp_base["pylsp"],
+        "display_name": "pylsp (with-config-override)",
+        "workspace_configuration": {
+          "pylsp.plugins.flake8.enabled": True,
+          "pylsp.plugins.pyflakes.enabled": False
+        }
+    }
+})

--- a/atest/fixtures/overrides.json
+++ b/atest/fixtures/overrides.json
@@ -1,0 +1,5 @@
+{
+    "@jupyterlab/statusbar-extension:plugin": {
+        "visible": true
+    }
+}

--- a/packages/jupyterlab-lsp/src/components/serverSettings.tsx
+++ b/packages/jupyterlab-lsp/src/components/serverSettings.tsx
@@ -210,12 +210,22 @@ const TabbedObjectTemplateFactory = (options: {
       );
     };
     const renderServerMetadata = (spec: TLanguageServerSpec) => {
+      const workspaceConfig = spec.workspace_configuration as Record<
+        string,
+        any
+      >;
       return (
         <div>
           <h4 className={'lsp-ServerSettings-content-name'}>
             {spec.display_name}
           </h4>
           <ServerLinksList specification={spec} />
+          {workspaceConfig ? (
+            <p className={'lsp-ServerSettings-content-specOverrides'}>
+              {trans.__('Default values set programatically for: ') +
+                Object.keys(workspaceConfig).join(', ')}
+            </p>
+          ) : null}
         </div>
       );
     };

--- a/packages/jupyterlab-lsp/style/index.css
+++ b/packages/jupyterlab-lsp/style/index.css
@@ -83,6 +83,10 @@
   margin: 1em;
 }
 
+.lsp-ServerSettings-content-specOverrides {
+  margin: 1em;
+}
+
 .lsp-ServerSettings-content > .form-group {
   padding-top: 0;
 }

--- a/python_packages/jupyter_lsp/jupyter_lsp/schema/schema.json
+++ b/python_packages/jupyter_lsp/jupyter_lsp/schema/schema.json
@@ -161,6 +161,11 @@
         },
         "version": {
           "$ref": "#/definitions/current-version"
+        },
+        "workspace_configuration": {
+          "description": "default values to include in the client `workspace/configuration` reply (also known as `serverSettings`). User may override these defaults. The keys should be fully qualified (dotted) names of settings (nested specification is not supported).",
+          "title": "Workspace configuration",
+          "type": "object"
         }
       },
       "title": "Server Spec Properties"


### PR DESCRIPTION
## References

Closes #821

## Code changes

- add optional `workspace_configuration` to language server spec which defines defaults for `workspace/configuration` reply (also known as `serverSettings`)
- split `SettingsSchemaManager`  from `SettingsUIManager` (non-breaking as this was never released)

## User-facing changes

The settings UI will notify of any defaults set by the server.

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
