### PR TITLE
Fix flaky completion tests

### DIFF
--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -295,6 +295,11 @@ Completes Correctly With R Double And Triple Colon
     [Setup]    Prepare File for Editing    R    completion    completion.R
     Place Cursor In File Editor At    2    7
     Wait Until Fully Initialized
+    # normally the completion adapter taking time to initialise is not a problem
+    # but because the token-based completion fallback would break our test example
+    # if it kicked off we try to avoid it by adding some delay
+    # TODO remove sleep after migrating to JupyterLab 4.0 native adapters.
+    Sleep    2s    Workaround completion adapter taking some time to initialize
     Trigger Completer
     Completer Should Suggest    .print.via.format
     Select Completer Suggestion    .print.via.format
@@ -319,6 +324,8 @@ Shows Documentation With CompletionItem Resolve
     [Setup]    Prepare File for Editing    R    completion    completion.R
     Place Cursor In File Editor At    8    7
     Wait Until Fully Initialized
+    # TODO remove sleep after migrating to JupyterLab 4.0 native adapters.
+    Sleep    2s    Workaround completion adapter taking some time to initialize
     Trigger Completer
     Completer Should Suggest    print.data.frame
     # if data.frame is not active, activate it (it should be in top 10 on any platform)

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/julia_language_server.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/julia_language_server.py
@@ -24,5 +24,5 @@ class JuliaLanguageServer(ShellSpec):
             issues="https://github.com/julia-vscode/LanguageServer.jl/issues",
         ),
         install=dict(julia='using Pkg; Pkg.add("LanguageServer")'),
-        config_schema=load_config_schema(key)
+        config_schema=load_config_schema(key),
     )

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/pyright.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/pyright.py
@@ -19,5 +19,5 @@ class PyrightLanguageServer(NodeModuleSpec):
             yarn="yarn add --dev {}".format(key),
             jlpm="jlpm add --dev {}".format(key),
         ),
-        config_schema=load_config_schema(key)
+        config_schema=load_config_schema(key),
     )

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/typescript_language_server.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/typescript_language_server.py
@@ -37,5 +37,5 @@ class TypescriptLanguageServer(NodeModuleSpec):
             yarn="yarn add --dev {}".format(key),
             jlpm="jlpm add --dev {}".format(key),
         ),
-        config_schema=load_config_schema(key)
+        config_schema=load_config_schema(key),
     )

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -40,10 +40,10 @@ ALL_ROBOT = [
 ROBOCOP_EXCLUDES = [
     "empty-lines-between-sections",
     "file-too-long",
-    "if-can-be-used",
     "missing-doc-keyword",
     "missing-doc-suite",
     "missing-doc-test-case",
+    "todo-in-comment",
     "too-long-test-case",
     "too-many-arguments",
     "too-many-calls-in-keyword",


### PR DESCRIPTION
Increase robustness of CI completion tests without addressing the underlying issue in adapter setup as that will go away once we migrate to JupyterLab 4.0 native completion.