### PR TITLE
Add option to show up hover tooltip automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 - features:
   - implement jump target selector and jump to references ([#739])
   - implement settings UI using native JupyterLab 3.3 UI ([#778])
+  - add option to show hover tooltip automatically ([#864], thanks @yamaton)
 - bug fixes
   - use correct websocket URL if configured as different from base URL ([#820], thanks @MikeSem)
   - clean up all completer styles when completer feature is disabled ([#829]).
   - fix `undefined` being inserted for path-like completion items with no `insertText` ([#833])
   - reduce signature flickering when typing and hover flicker when moving mouse ([#836])
+  - fix sporadic misplacement of hover tooltips ([#860], thanks @yamaton)
 - refactoring:
   - changed NPM packages namespace from `@krassowski` to `@jupyter-lsp` ([#862])
   - move client capabilities to features ([#738])
@@ -34,6 +36,8 @@
 [#829]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/829
 [#833]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/833
 [#836]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/836
+[#860]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/860
+[#864]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/864
 
 ### `@krassowski/jupyterlab-lsp 3.10.1` (2022-03-21)
 

--- a/atest/05_Features/Hover.robot
+++ b/atest/05_Features/Hover.robot
@@ -15,6 +15,24 @@ ${HOVER_SIGNAL}     css:.cm-lsp-hover-available
 
 
 *** Test Cases ***
+Hover Does Not Trigger Automatically
+    Enter Cell Editor    1
+    ${sel} =    Last Occurrence    python_add
+    Configure JupyterLab Plugin    {"autoActivate": false}
+    ...    plugin id=${HOVER PLUGIN ID}
+    Trigger Automatically By Hover    ${sel}
+    Sleep    1s
+    Element Text Should Be    ${HOVER_SIGNAL}    python_add
+    Page Should Not Contain Element    ${HOVER_BOX}
+
+Hover Triggers Automatically
+    Enter Cell Editor    1
+    ${sel} =    Last Occurrence    python_add
+    Configure JupyterLab Plugin    {"delay": 100, "autoActivate": true}
+    ...    plugin id=${HOVER PLUGIN ID}
+    Trigger Automatically By Hover    ${sel}
+    Wait Until Keyword Succeeds    4x    0.1s    Page Should Contain Element    ${HOVER_BOX}
+
 Hover works in notebooks
     Enter Cell Editor    1
     Trigger Tooltip    python_add
@@ -55,6 +73,14 @@ Last Occurrence
     ${sel} =    Set Variable If    "${symbol}".startswith(("xpath", "css"))    ${symbol}
     ...    xpath:(//span[@role="presentation"][contains(., "${symbol}")])[last()]
     RETURN    ${sel}
+
+Trigger Automatically By Hover
+    [Arguments]    ${sel}
+    # bring the cursor to the element
+    Wokraround Visibility Problem    ${sel}
+    Mouse Over    ${sel}
+    Wait Until Page Contains Element    ${HOVER_SIGNAL}    timeout=10s
+    Mouse Over And Wiggle    ${sel}    5
 
 Trigger Via Hover With Modifier
     [Arguments]    ${sel}

--- a/atest/Variables.resource
+++ b/atest/Variables.resource
@@ -57,6 +57,7 @@ ${COMPLETION PLUGIN ID}         @jupyter-lsp/jupyterlab-lsp:completion
 ${HIGHLIGHTS PLUGIN ID}         @jupyter-lsp/jupyterlab-lsp:highlights
 ${JUMP PLUGIN ID}               @jupyter-lsp/jupyterlab-lsp:jump_to
 ${DIAGNOSTICS PLUGIN ID}        @jupyter-lsp/jupyterlab-lsp:diagnostics
+${HOVER PLUGIN ID}              @jupyter-lsp/jupyterlab-lsp:hover
 ${CSS USER SETTINGS}            .jp-SettingsRawEditor-user
 ${JLAB XP CLOSE SETTINGS}
 ...                             ${JLAB XP DOCK TAB}\[contains(., 'Settings')]/*[contains(@class, 'm-TabBar-tabCloseIcon')]

--- a/packages/jupyterlab-lsp/schema/hover.json
+++ b/packages/jupyterlab-lsp/schema/hover.json
@@ -16,7 +16,7 @@
       "type": "number",
       "default": 300,
       "minimum": 0,
-      "description": "Number of milliseconds after which the hover tooltip should be shown. Ignored if 'Automatic hover' is OFF."
+      "description": "Number of milliseconds after which the hover tooltip should be shown. Ignored if 'Automatic hover' is off."
     },
     "modifierKey": {
       "title": "Modifier key",

--- a/packages/jupyterlab-lsp/schema/hover.json
+++ b/packages/jupyterlab-lsp/schema/hover.json
@@ -5,6 +5,19 @@
   "description": "LSP Hover over the code tooltip settings.",
   "type": "object",
   "properties": {
+    "autoActivate": {
+      "title": "Automatic hover",
+      "type": "boolean",
+      "default": false,
+      "description": "Automatic activation of hover without pressing a key. It will still be possible to show up tooltips with the modifier key."
+    },
+    "delay": {
+      "title": "Hover delay",
+      "type": "number",
+      "default": 300,
+      "minimum": 0,
+      "description": "Number of milliseconds after which the hover tooltip should be shown. Ignored if 'Automatic hover' is OFF."
+    },
     "modifierKey": {
       "title": "Modifier key",
       "type": "string",

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -386,10 +386,13 @@ export class HoverCM extends CodeMirrorIntegration {
   protected async _updateUnderlineAndTooltip(
     event: MouseEvent
   ): Promise<boolean> {
-    const target = event.target as HTMLElement;
+    const target = event.target;
 
     // if over an empty space in a line (and not over a token) then not worth checking
-    if (target.classList.contains('CodeMirror-line')) {
+    if (
+      target == null ||
+      (target as HTMLElement).classList.contains('CodeMirror-line')
+    ) {
       this.remove_range_highlight();
       return false;
     }

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -143,6 +143,10 @@ export class HoverCM extends CodeMirrorIntegration {
     return this.settings.composite.modifierKey;
   }
 
+  protected get isHoverAutomatic(): boolean {
+    return this.settings.composite.autoActivate;
+  }
+
   get lab_integration() {
     return super.lab_integration as HoverLabIntegration;
   }
@@ -390,7 +394,8 @@ export class HoverCM extends CodeMirrorIntegration {
       return false;
     }
 
-    const show_tooltip = getModifierState(event, this.modifierKey);
+    const show_tooltip =
+      this.isHoverAutomatic || getModifierState(event, this.modifierKey);
 
     // currently the events are coming from notebook panel; ideally these would be connected to individual cells,
     // (only cells with code) instead, but this is more complex to implement right. In any case filtering
@@ -440,6 +445,7 @@ export class HoverCM extends CodeMirrorIntegration {
         ]);
       }
       let response_data = this.restore_from_cache(document, virtual_position);
+      let delay_ms = this.settings.composite.delay;
 
       if (response_data == null) {
         const promise = this.debounced_get_hover.invoke();
@@ -473,10 +479,19 @@ export class HoverCM extends CodeMirrorIntegration {
           };
 
           this.cache.store(response_data);
+          delay_ms = Math.max(
+            0,
+            this.settings.composite.delay -
+              this.settings.composite.throttlerDelay
+          );
         } else {
           this.remove_range_highlight();
           return false;
         }
+      }
+
+      if (this.isHoverAutomatic) {
+        await new Promise(resolve => setTimeout(resolve, delay_ms));
       }
 
       return this.handleResponse(response_data, root_position, show_tooltip);

--- a/python_packages/jupyterlab_lsp/setup.py
+++ b/python_packages/jupyterlab_lsp/setup.py
@@ -6,7 +6,9 @@ import setuptools
 
 LABEXTENSIONS_DIR = Path("jupyterlab_lsp/labextensions")
 LABEXTENSIONS_INSTALL_DIR = Path("share") / "jupyter" / "labextensions"
-LAB_PACKAGE_PATH = LABEXTENSIONS_DIR / "@jupyter-lsp" / "jupyterlab-lsp" / "package.json"
+LAB_PACKAGE_PATH = (
+    LABEXTENSIONS_DIR / "@jupyter-lsp" / "jupyterlab-lsp" / "package.json"
+)
 
 
 def get_data_files():


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->
**[EDIT]** Screenshot replacement after the config rewording.

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above).
Use "fixes" and "closes" linking phrases as appropriate. -->

https://github.com/jupyter-lsp/jupyterlab-lsp/issues/362

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

* Wait for `delay` period before showing a hover tooltip IF `autoActivate` is enabled.
* Fix `TypeError` warning by taking care of types.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Add 'Automatic hover' and 'Hover delay' to 'Code Hover' in Advanced Setting Editor. They are disabled by default.
Here is a screenshot:


![automatic-hover-setting](https://user-images.githubusercontent.com/256288/192662048-19dfc8a9-4731-44e2-98aa-a991b297d787.png)



<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->
None.

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
