### PR TITLE
Implement eliding for paths/files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - implement jump target selector and jump to references ([#739])
   - implement settings UI using native JupyterLab 3.3 UI ([#778])
   - add option to show hover tooltip automatically ([#864], thanks @yamaton)
+  - implement eliding for long paths/files in completer ([#893])
 - bug fixes:
   - use correct websocket URL if configured as different from base URL ([#820], thanks @MikeSem)
   - clean up all completer styles when completer feature is disabled ([#829]).
@@ -61,6 +62,7 @@
 [#860]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/860
 [#864]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/864
 [#882]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/882
+[#893]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/893
 
 ### `@krassowski/jupyterlab-lsp 3.10.1` (2022-03-21)
 

--- a/packages/completion-theme/style/index.css
+++ b/packages/completion-theme/style/index.css
@@ -25,7 +25,7 @@
 }
 
 .lsp-completer.jp-Completer {
-  --lsp-completer-max-label-width: 300px;
+  --lsp-completer-max-label-width: 350px;
   --lsp-completer-max-detail-width: 200px;
 }
 
@@ -91,6 +91,22 @@ body[data-lsp-completer-layout='detail-below'] .jp-Completer-match {
 
 .lsp-completer .jp-mod-active .jp-Completer-typeExtended {
   text-overflow: clip;
+}
+
+.lsp-completer mark.lsp-elide:first-child {
+  display: inline-block;
+  overflow-x: clip;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  /* stretch to as much space as possible */
+  flex-shrink: 1;
+  /* always reserve small space to fit the ellipsis */
+  min-width: 20px;
+}
+
+.lsp-completer .lsp-elide-wrapper {
+  display: flex;
 }
 
 body[data-lsp-completer-layout='detail-below'] .jp-Completer-typeExtended {

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -8,7 +8,7 @@ import { Signal } from '@lumino/signaling';
 import { ILSPLogConsole } from '../../tokens';
 
 import { CompletionLabIntegration } from './completion';
-import { LazyCompletionItem } from './item';
+import { LazyCompletionItem, IExtendedCompletionItem } from './item';
 
 export interface ICompletionData {
   item: LazyCompletionItem;
@@ -147,8 +147,8 @@ export class LSPCompletionRenderer
     return li;
   }
 
-  private _elideMark(item: LazyCompletionItem, li: HTMLLIElement) {
-    if (!item) {
+  private _elideMark(item: IExtendedCompletionItem, li: HTMLLIElement) {
+    if (!item || !item.type) {
       return;
     }
     const type = item.type.toLowerCase();


### PR DESCRIPTION
## References

Elide long path completions, fixes #787 and fixes https://github.com/jupyterlab/jupyterlab/issues/12830

## Code changes

The content of the first highlighted (`<mark>`ed) part is elided for paths

- `direction: rtl` is used to reverse side of eliding
   - to prevent wrong placement of neutral BiDi characters (e.g. `.` or `/`) `<bdo>` tag wrapper is used for `<mark>` contents; the alternative, CSS `unicode-bidi` would also require an HTML wrapper, hence BDO tag is a simpler choice.
- `display:flex`/`flex-shrink: 1` is used to stretch the mark to as much as possible

I also explored a possibility of eliding of the middle part of the path based on separator, but there does not appear to be a good solution (which would have good performance with large number of matches).

## User-facing changes

Long paths are elided. User can hover over the elided part to see title with full contents.

![Screenshot from 2023-01-02 03-59-58](https://user-images.githubusercontent.com/5832902/210194231-6204c891-d28c-44d2-8589-07aa351b5a48.png)

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
