### PR TITLE
Fix `overrides.json` not being picked up in defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Changelog
 
+### `@jupyter-lsp/jupyterlab-lsp 4.0.1` (unreleased)
+
+- bug fixes
+  - overrides from `overrides.json` are now picked up again ([#919])
+
+### `jupyter-lsp 2.0.1` (unreleased)
+
+- bug fixes:
+  - pyright schema now includes required `python.` prefixes ([#919])
+
+[#919]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/919
+
 ### `@jupyter-lsp/jupyterlab-lsp 4.0.0` (2023-03-15)
 
 Requires JupyterLab `>=3.6.0,<4.0.0a0` and Python 3.8 or newer.
@@ -9,6 +21,7 @@ Requires JupyterLab `>=3.6.0,<4.0.0a0` and Python 3.8 or newer.
   - implement settings UI using native JupyterLab 3.3 UI ([#778])
   - add option to show hover tooltip automatically ([#864], thanks @yamaton)
   - implement eliding for long paths/files in completer ([#893])
+  - allow to pass default workspace config (`serverSettings`) in specs ([#856])
 - bug fixes:
   - use correct websocket URL if configured as different from base URL ([#820], thanks @MikeSem)
   - clean up all completer styles when completer feature is disabled ([#829]).
@@ -50,6 +63,7 @@ Requires JupyterLab `>=3.6.0,<4.0.0a0` and Python 3.8 or newer.
 - performance:
   - `entry_point` discovery is deferred until server has started, improving
     `jupyter_server` startup time ([#852])
+- allow to pass default workspace config (`serverSettings`) in specs ([#856])
 
 [#724]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/724
 [#738]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/738
@@ -63,6 +77,7 @@ Requires JupyterLab `>=3.6.0,<4.0.0a0` and Python 3.8 or newer.
 [#833]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/833
 [#836]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/836
 [#852]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/852
+[#856]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/856
 [#860]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/860
 [#864]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/864
 [#867]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/867

--- a/atest/07_Configuration.robot
+++ b/atest/07_Configuration.robot
@@ -16,9 +16,18 @@ Python
     ...    undefined name 'foo' (pyflakes)
     ...    undefined name 'foo' (flake8)
 
-Python (programmatically)
+Python (server-side via overrides.json)
+    [Documentation]    same as "Python" but changing the defaults in server specification via `overrides.json`
+    Settings Should Change Editor Diagnostics    Python    style.py    pylsp-with-override-json
+    ...    settings=100
+    ...    before=undefined name 'foo' (pyflakes)
+    ...    after=undefined name 'foo' (flake8)
+    ...    setting_key=priority
+    ...    needs reload=${True}
+
+Python (server-side via spec)
     [Documentation]    same as "Python" but changing the defaults in server specification via `workspace_configuration`
-    Settings Should Change Editor Diagnostics    Python    style.py    pylsp-with-config-override
+    Settings Should Change Editor Diagnostics    Python    style.py    pylsp-with-override-spec
     ...    settings=100
     ...    before=undefined name 'foo' (pyflakes)
     ...    after=undefined name 'foo' (flake8)

--- a/atest/Keywords.resource
+++ b/atest/Keywords.resource
@@ -8,6 +8,7 @@ Resource    Variables.resource
 Library     ./logcheck.py
 Library     ./ports.py
 Library     ./config.py
+Library     ./paths.py
 
 
 *** Keywords ***
@@ -41,13 +42,14 @@ Create Notebok Server Config
     Set Environment Variable
     ...    name=JUPYTER_CONFIG_DIR
     ...    value=${NOTEBOOK DIR}
+    ${jupyterlab_dir} =    Get JupyterLab Path
     ${extra_node_roots} =    Create List    ${ROOT}
     ${port} =    Get Unused Port
     Set Global Variable    ${PORT}    ${port}
     Set Global Variable    ${URL}    http://localhost:${PORT}${BASE URL}
     Copy File    ${FIXTURES}${/}${JPSERVER CONF JSON}    ${conf}
     Copy File    ${FIXTURES}${/}${JPSERVER CONF PY}    ${NOTEBOOK DIR}${/}${JPSERVER CONF PY}
-    Copy File    ${FIXTURES}${/}overrides.json    ${NOTEBOOK DIR}${/}overrides.json
+    Copy File    ${FIXTURES}${/}overrides.json    ${jupyterlab_dir}${/}settings${/}overrides.json
     Update Jupyter Config    ${conf}    ServerApp
     ...    base_url=${BASE URL}
     ...    port=${PORT}

--- a/atest/fixtures/jupyter_server_config.py
+++ b/atest/fixtures/jupyter_server_config.py
@@ -7,12 +7,16 @@ pylsp_base: dict = PythonLSPServer()(manager)
 
 
 c.LanguageServerManager.language_servers.update({
-    "pylsp-with-config-override": {
+    "pylsp-with-override-spec": {
         **pylsp_base["pylsp"],
-        "display_name": "pylsp (with-config-override)",
+        "display_name": "pylsp (with override via server spec)",
         "workspace_configuration": {
           "pylsp.plugins.flake8.enabled": True,
           "pylsp.plugins.pyflakes.enabled": False
         }
+    },
+    "pylsp-with-override-json": {
+        **pylsp_base["pylsp"],
+        "display_name": "pylsp (with override via overrides.json)"
     }
 })

--- a/atest/fixtures/overrides.json
+++ b/atest/fixtures/overrides.json
@@ -4,9 +4,6 @@
   },
   "@jupyter-lsp/jupyterlab-lsp:plugin": {
     "language_servers": {
-      "pyright": {
-        "priority": 1000
-      },
       "pylsp-with-override-json": {
         "serverSettings": {
           "pylsp.plugins.flake8.enabled": true,

--- a/atest/fixtures/overrides.json
+++ b/atest/fixtures/overrides.json
@@ -1,5 +1,18 @@
 {
-    "@jupyterlab/statusbar-extension:plugin": {
-        "visible": true
+  "@jupyterlab/statusbar-extension:plugin": {
+    "visible": true
+  },
+  "@jupyter-lsp/jupyterlab-lsp:plugin": {
+    "language_servers": {
+      "pyright": {
+        "priority": 1000
+      },
+      "pylsp-with-override-json": {
+        "serverSettings": {
+          "pylsp.plugins.flake8.enabled": true,
+          "pylsp.plugins.pyflakes.enabled": false
+        }
+      }
     }
+  }
 }

--- a/atest/paths.py
+++ b/atest/paths.py
@@ -1,0 +1,8 @@
+"""work with jupyter paths"""
+
+from jupyterlab.commands import get_app_dir
+
+
+def get_jupyterlab_path():
+    """Get JupyterLab Application Directory path"""
+    return get_app_dir()

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/config/pyright.schema.json
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/config/pyright.schema.json
@@ -1,589 +1,490 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Pyright Language Server Configuration",
-  "description": "Pyright Configuration Schema. Patterns modified to allow empty, added title, #/definitions/diagnostic simplified; title → description. Distributed under MIT License, Copyright (c) Microsoft Corporation.",
+  "description": "Pyright Configuration Schema. Distributed under MIT License, Copyright (c) Microsoft Corporation.",
   "allowComments": true,
   "allowTrailingCommas": true,
   "type": "object",
-  "definitions": {
-    "diagnostic": {
-      "type": "string",
-      "enum": ["none", "information", "warning", "error"]
-    }
-  },
   "properties": {
-    "include": {
-      "$id": "#/properties/include",
+    "python.analysis.autoImportCompletions": {
+      "type": "boolean",
+      "default": true,
+      "description": "Offer auto-import completions.",
+      "scope": "resource"
+    },
+    "python.analysis.autoSearchPaths": {
+      "type": "boolean",
+      "default": true,
+      "description": "Automatically add common search paths like 'src'?",
+      "scope": "resource"
+    },
+    "python.analysis.extraPaths": {
       "type": "array",
-      "description": "Files and directories included in type analysis",
+      "default": [],
       "items": {
-        "$id": "#/properties/include/items",
-        "type": "string",
-        "description": "File or directory to include in type analysis",
-        "pattern": "^(.*)$"
-      }
-    },
-    "exclude": {
-      "$id": "#/properties/exclude",
-      "type": "array",
-      "description": "Files and directories excluded from type analysis",
-      "items": {
-        "$id": "#/properties/exclude/items",
-        "type": "string",
-        "description": "File or directory to exclude from type analysis",
-        "pattern": "^(.*)$"
-      }
-    },
-    "ignore": {
-      "$id": "#/properties/ignore",
-      "type": "array",
-      "description": "Files and directories whose diagnostics are suppressed",
-      "items": {
-        "$id": "#/properties/ignore/items",
-        "type": "string",
-        "description": "File or directory where diagnostics should be suppressed",
-        "pattern": "^(.*)$"
-      }
-    },
-    "strict": {
-      "$id": "#/properties/strict",
-      "type": "array",
-      "description": "Files and directories that should use 'strict' type checking rules",
-      "items": {
-        "$id": "#/properties/strict/items",
-        "type": "string",
-        "description": "File or directory that should use 'strict' type checking rules",
-        "pattern": "^(.*)$"
-      }
-    },
-    "defineConstant": {
-      "$id": "#/properties/defineConstant",
-      "type": "object",
-      "description": "Identifiers that should be treated as constants",
-      "properties": {},
-      "additionalProperties": {
-        "type": ["string", "boolean"],
-        "description": "Value of constant (boolean or string)"
-      }
-    },
-    "typeCheckingMode": {
-      "$id": "#/properties/typeCheckingMode",
-      "type": "string",
-      "enum": ["off", "basic", "strict"],
-      "description": "Specifies the default rule set to use for type checking",
-      "default": "basic"
-    },
-    "useLibraryCodeForTypes": {
-      "$id": "#/properties/useLibraryCodeForTypes",
-      "type": "boolean",
-      "description": "Use library implementations to extract type information when type stub is not present",
-      "default": false
-    },
-    "typeshedPath": {
-      "$id": "#/properties/typeshedPath",
-      "type": "string",
-      "description": "Path to directory containing typeshed type stub files",
-      "default": "",
-      "pattern": "^(.*)$"
-    },
-    "stubPath": {
-      "$id": "#/properties/stubPath",
-      "type": "string",
-      "description": "Path to directory containing custom type stub files",
-      "default": "",
-      "examples": ["src/typestubs"],
-      "pattern": "^(.*)$"
-    },
-    "strictListInference": {
-      "$id": "#/properties/strictListInference",
-      "type": "boolean",
-      "description": "Infer strict types for list expressions",
-      "default": false
-    },
-    "strictSetInference": {
-      "$id": "#/properties/strictSetInference",
-      "type": "boolean",
-      "description": "Infer strict types for set expressions",
-      "default": false
-    },
-    "strictDictionaryInference": {
-      "$id": "#/properties/strictDictionaryInference",
-      "type": "boolean",
-      "description": "Infer strict types for dictionary expressions",
-      "default": false
-    },
-    "strictParameterNoneValue": {
-      "$id": "#/properties/strictParameterNoneValue",
-      "type": "boolean",
-      "description": "Allow implicit Optional when default parameter value is None",
-      "default": true
-    },
-    "enableTypeIgnoreComments": {
-      "$id": "#/properties/enableTypeIgnoreComments",
-      "type": "boolean",
-      "description": "Allow \"# type: ignore\" comments",
-      "default": true
-    },
-    "reportGeneralTypeIssues": {
-      "$id": "#/properties/reportGeneralTypeIssues",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of general type issues",
-      "default": "error"
-    },
-    "reportPropertyTypeMismatch": {
-      "$id": "#/properties/reportPropertyTypeMismatch",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of property getter/setter type mismatches",
-      "default": "none"
-    },
-    "reportFunctionMemberAccess": {
-      "$id": "#/properties/reportFunctionMemberAccess",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of member accesses on function objects",
-      "default": "none"
-    },
-    "reportMissingImports": {
-      "$id": "#/properties/reportMissingImports",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of imports that cannot be resolved",
-      "default": "error"
-    },
-    "reportMissingModuleSource": {
-      "$id": "#/properties/reportMissingModuleSource",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of imports that cannot be resolved to source files",
-      "default": "warning"
-    },
-    "reportMissingTypeStubs": {
-      "$id": "#/properties/reportMissingTypeStubs",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of imports that cannot be resolved to type stub files",
-      "default": "none"
-    },
-    "reportImportCycles": {
-      "$id": "#/properties/reportImportCycles",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of module imports that create cycles in import graph",
-      "default": "none"
-    },
-    "reportUnusedImport": {
-      "$id": "#/properties/reportUnusedImport",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of imported symbols that are not referenced within the source file",
-      "default": "none"
-    },
-    "reportUnusedClass": {
-      "$id": "#/properties/reportUnusedClass",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of private classes that are not accessed",
-      "default": "none"
-    },
-    "reportUnusedFunction": {
-      "$id": "#/properties/reportUnusedFunction",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of private functions or methods that are not accessed",
-      "default": "none"
-    },
-    "reportUnusedVariable": {
-      "$id": "#/properties/reportUnusedVariable",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of local variables that are not accessed",
-      "default": "none"
-    },
-    "reportDuplicateImport": {
-      "$id": "#/properties/reportDuplicateImport",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of symbols or modules that are imported more than once",
-      "default": "none"
-    },
-    "reportWildcardImportFromLibrary": {
-      "$id": "#/properties/reportWildcardImportFromLibrary",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of wlidcard import from external library",
-      "default": "none"
-    },
-    "reportOptionalSubscript": {
-      "$id": "#/properties/reportOptionalSubscript",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to subscript (index) a variable with Optional type",
-      "default": "error"
-    },
-    "reportOptionalMemberAccess": {
-      "$id": "#/properties/reportOptionalMemberAccess",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to access a member of a variable with Optional type",
-      "default": "error"
-    },
-    "reportOptionalCall": {
-      "$id": "#/properties/reportOptionalCall",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to call a variable with Optional type",
-      "default": "error"
-    },
-    "reportOptionalIterable": {
-      "$id": "#/properties/reportOptionalIterable",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to use an Optional type as an iterable value",
-      "default": "error"
-    },
-    "reportOptionalContextManager": {
-      "$id": "#/properties/reportOptionalContextManager",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to use an Optional type as a parameter to a with statement",
-      "default": "error"
-    },
-    "reportOptionalOperand": {
-      "$id": "#/properties/reportOptionalOperand",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to use an Optional type as an operand for a binary or unary operator",
-      "default": "error"
-    },
-    "reportTypedDictNotRequiredAccess": {
-      "$id": "#/properties/reportTypedDictNotRequiredAccess",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to access a non-required key in a TypedDict without a check for its presence",
-      "default": "error"
-    },
-    "reportUntypedFunctionDecorator": {
-      "$id": "#/properties/reportUntypedFunctionDecorator",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of function decorators without type annotations, which obscure function types",
-      "default": "none"
-    },
-    "reportUntypedClassDecorator": {
-      "$id": "#/properties/reportUntypedClassDecorator",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of class decorators without type annotations, which obscure class types",
-      "default": "none"
-    },
-    "reportUntypedBaseClass": {
-      "$id": "#/properties/reportUntypedBaseClass",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of a base class of an unknown type, which obscures most type checking for the class",
-      "default": "none"
-    },
-    "reportUntypedNamedTuple": {
-      "$id": "#/properties/reportUntypedNamedTuple",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of a named tuple definition that does not contain type information",
-      "default": "none"
-    },
-    "reportPrivateUsage": {
-      "$id": "#/properties/reportPrivateUsage",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of private variables and functions used outside of the owning class or module and usage of protected members outside of subclasses",
-      "default": "none"
-    },
-    "reportTypeCommentUsage": {
-      "$id": "#/properties/reportTypeCommentUsage",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of deprecated type comment usage",
-      "default": "none"
-    },
-    "reportPrivateImportUsage": {
-      "$id": "#/properties/reportPrivateImportUsage",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of improper usage of symbol imported from a \"py.typed\" module that is not re-exported from that module",
-      "default": "error"
-    },
-    "reportConstantRedefinition": {
-      "$id": "#/properties/reportConstantRedefinition",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to redefine variables that are in all-caps",
-      "default": "none"
-    },
-    "reportIncompatibleMethodOverride": {
-      "$id": "#/properties/reportIncompatibleMethodOverride",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of method overrides in subclasses that redefine the method in an incompatible way",
-      "default": "none"
-    },
-    "reportIncompatibleVariableOverride": {
-      "$id": "#/properties/reportIncompatibleVariableOverride",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of overrides in subclasses that redefine a variable in an incompatible way",
-      "default": "none"
-    },
-    "reportInconsistentConstructor": {
-      "$id": "#/properties/reportInconsistentConstructor",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of __init__ and __new__ methods whose signatures are inconsistent",
-      "default": "none"
-    },
-    "reportOverlappingOverload": {
-      "$id": "#/properties/reportOverlappingOverload",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of function overloads that overlap in signature and obscure each other or do not agree on return type",
-      "default": "none"
-    },
-    "reportMissingSuperCall": {
-      "$id": "#/properties/reportMissingSuperCall",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of missing call to parent class for inherited `__init__` methods",
-      "default": "none"
-    },
-    "reportUninitializedInstanceVariable": {
-      "$id": "#/properties/reportUninitializedInstanceVariable",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of instance variables that are not initialized in the constructor",
-      "default": "none"
-    },
-    "reportInvalidStringEscapeSequence": {
-      "$id": "#/properties/reportInvalidStringEscapeSequence",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of invalid escape sequences used within string literals",
-      "default": "warning"
-    },
-    "reportUnknownParameterType": {
-      "$id": "#/properties/reportUnknownParameterType",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting input and return parameters whose types are unknown",
-      "default": "none"
-    },
-    "reportUnknownArgumentType": {
-      "$id": "#/properties/reportUnknownArgumentType",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting argument expressions whose types are unknown",
-      "default": "none"
-    },
-    "reportUnknownLambdaType": {
-      "$id": "#/properties/reportUnknownLambdaType",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting input and return parameters for lambdas whose types are unknown",
-      "default": "none"
-    },
-    "reportUnknownVariableType": {
-      "$id": "#/properties/reportUnknownVariableType",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting local variables whose types are unknown",
-      "default": "none"
-    },
-    "reportUnknownMemberType": {
-      "$id": "#/properties/reportUnknownMemberType",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting class and instance variables whose types are unknown",
-      "default": "none"
-    },
-    "reportMissingParameterType": {
-      "$id": "#/properties/reportMissingParameterType",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting input parameters that are missing a type annotation",
-      "default": "none"
-    },
-    "reportMissingTypeArgument": {
-      "$id": "#/properties/reportMissingTypeArgument",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting generic class reference with missing type arguments",
-      "default": "none"
-    },
-    "reportInvalidTypeVarUse": {
-      "$id": "#/properties/reportInvalidTypeVarUse",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting improper use of type variables within function signatures",
-      "default": "warning"
-    },
-    "reportCallInDefaultInitializer": {
-      "$id": "#/properties/reportCallInDefaultInitializer",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting usage of function calls within a default value initializer expression",
-      "default": "none"
-    },
-    "reportUnnecessaryIsInstance": {
-      "$id": "#/properties/reportUnnecessaryIsInstance",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting calls to 'isinstance' or 'issubclass' where the result is statically determined to be always true",
-      "default": "none"
-    },
-    "reportUnnecessaryCast": {
-      "$id": "#/properties/reportUnnecessaryCast",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting calls to 'cast' that are unnecessary",
-      "default": "none"
-    },
-    "reportUnnecessaryComparison": {
-      "$id": "#/properties/reportUnnecessaryComparison",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting the use of '==' or '!=' comparisons that are unnecessary",
-      "default": "none"
-    },
-    "reportUnnecessaryContains": {
-      "$id": "#/properties/reportUnnecessaryContains",
-      "$ref": "#/definitions/diagnostic",
-      "title": "Controls reporting the use of 'in' operations that are unnecessary",
-      "default": "none"
-    },
-    "reportAssertAlwaysTrue": {
-      "$id": "#/properties/reportAssertAlwaysTrue",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting assert expressions that will always evaluate to true",
-      "default": "warning"
-    },
-    "reportSelfClsParameterName": {
-      "$id": "#/properties/reportSelfClsParameterName",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting assert expressions that will always evaluate to true",
-      "default": "warning"
-    },
-    "reportImplicitStringConcatenation": {
-      "$id": "#/properties/reportImplicitStringConcatenation",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting usage of implicit concatenation of string literals",
-      "default": "warning"
-    },
-    "reportUnboundVariable": {
-      "$id": "#/properties/reportUnboundVariable",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to use an unbound or possibly unbound variable",
-      "default": "error"
-    },
-    "reportUndefinedVariable": {
-      "$id": "#/properties/reportUndefinedVariable",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of attempts to use an undefined variable",
-      "default": "error"
-    },
-    "reportInvalidStubStatement": {
-      "$id": "#/properties/reportInvalidStubStatement",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of type stub statements that do not conform to PEP 484",
-      "default": "none"
-    },
-    "reportIncompleteStub": {
-      "$id": "#/properties/reportIncompleteStub",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of incomplete type stubs that declare a module-level __getattr__ function",
-      "default": "none"
-    },
-    "reportUnsupportedDunderAll": {
-      "$id": "#/properties/reportUnsupportedDunderAll",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of unsupported operations performed on __all__",
-      "default": "warning"
-    },
-    "reportUnusedCallResult": {
-      "$id": "#/properties/reportUnusedCallResult",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of call expressions whose results are not consumed",
-      "default": "none"
-    },
-    "reportUnusedCoroutine": {
-      "$id": "#/properties/reportUnusedCoroutine",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of call expressions that returns Coroutine whose results are not consumed",
-      "default": "error"
-    },
-    "reportUnusedExpression": {
-      "$id": "#/properties/reportUnusedExpression",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of simple expressions whose value is not used in any way",
-      "default": "warning"
-    },
-    "reportUnnecessaryTypeIgnoreComment": {
-      "$id": "#/properties/reportUnnecessaryTypeIgnoreComment",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of '# type: ignore' comments that have no effect'",
-      "default": "none"
-    },
-    "reportMatchNotExhaustive": {
-      "$id": "#/properties/reportMatchNotExhaustive",
-      "$ref": "#/definitions/diagnostic",
-      "description": "Controls reporting of 'match' statements that do not exhaustively match all possible values",
-      "default": "none"
-    },
-    "extraPaths": {
-      "$id": "#/properties/extraPaths",
-      "type": "array",
+        "type": "string"
+      },
       "description": "Additional import search resolution paths",
-      "items": {
-        "$id": "#/properties/extraPaths/items",
-        "type": "string",
-        "description": "Additional import search resolution path",
-        "default": "",
-        "pattern": "^(.*)$"
-      }
+      "scope": "resource"
     },
-    "pythonVersion": {
-      "$id": "#/properties/pythonVersion",
+    "python.analysis.stubPath": {
       "type": "string",
-      "description": "Python version to assume during type analysis",
-      "default": "",
-      "examples": ["3.7"]
+      "default": "typings",
+      "description": "Path to directory containing custom type stub files.",
+      "scope": "resource"
     },
-    "pythonPlatform": {
-      "$id": "#/properties/pythonPlatform",
+    "python.analysis.diagnosticMode": {
       "type": "string",
-      "description": "Python platform to assume during type analysis",
-      "default": "",
-      "examples": ["Linux"],
-      "pattern": "^(Linux|Windows|Darwin|All)?$"
+      "default": "openFilesOnly",
+      "enum": ["openFilesOnly", "workspace"],
+      "enumDescriptions": [
+        "Analyzes and reports errors on only open files.",
+        "Analyzes and reports errors on all files in the workspace."
+      ],
+      "scope": "resource"
     },
-    "venvPath": {
-      "$id": "#/properties/venvPath",
-      "type": "string",
-      "description": "Path to directory containing a folder of virtual environments",
-      "default": "",
-      "pattern": "^(.*)$"
-    },
-    "venv": {
-      "$id": "#/properties/venv",
-      "type": "string",
-      "description": "Name of virtual environment subdirectory within venvPath",
-      "default": "",
-      "examples": ["python37"],
-      "pattern": "^(.*)$"
-    },
-    "verboseOutput": {
-      "$id": "#/properties/verboseOutput",
-      "type": "boolean",
-      "description": "Output verbose logging",
-      "default": false
-    },
-    "executionEnvironments": {
-      "$id": "#/properties/executionEnvironments",
-      "type": "array",
-      "description": "Analysis settings to use for specified subdirectories of code",
-      "items": {
-        "$id": "#/properties/executionEnvironments/items",
-        "type": "object",
-        "description": "Analysis settings to use for specified subdirectories of code",
-        "required": ["root"],
-        "properties": {
-          "root": {
-            "$id": "#/properties/executionEnvironments/items/properties/root",
-            "type": "string",
-            "description": "Path to code subdirectory to which these settings apply",
-            "default": "",
-            "pattern": "^(.*)$"
-          },
-          "extraPaths": {
-            "$id": "#/properties/executionEnvironments/items/properties/extraPaths",
-            "type": "array",
-            "description": "Additional import search resolution paths",
-            "items": {
-              "$id": "#/properties/executionEnvironments/items/properties/extraPaths/items",
-              "type": "string",
-              "description": "Additional import search resolution path",
-              "default": "",
-              "pattern": "^(.*)$"
-            }
-          },
-          "pythonVersion": {
-            "$id": "#/properties/executionEnvironments/items/properties/pythonVersion",
-            "type": "string",
-            "description": "Python version to assume during type analysis",
-            "default": "",
-            "examples": ["3.7"]
-          },
-          "pythonPlatform": {
-            "$id": "#/properties/executionEnvironments/items/properties/pythonPlatform",
-            "type": "string",
-            "description": "Python platform to assume during type analysis",
-            "default": "",
-            "examples": ["Linux"],
-            "pattern": "^(Linux|Windows|Darwin|All)?$"
-          }
+    "python.analysis.diagnosticSeverityOverrides": {
+      "type": "object",
+      "description": "Allows a user to override the severity levels for individual diagnostics.",
+      "scope": "resource",
+      "properties": {
+        "reportGeneralTypeIssues": {
+          "type": "string",
+          "description": "Diagnostics for general type inconsistencies, unsupported operations, argument/parameter mismatches, etc. Covers all of the basic type-checking rules not covered by other rules. Does not include syntax errors.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportPropertyTypeMismatch": {
+          "type": "string",
+          "description": "Diagnostics for property whose setter and getter have mismatched types.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportFunctionMemberAccess": {
+          "type": "string",
+          "description": "Diagnostics for member accesses on functions.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportMissingImports": {
+          "type": "string",
+          "description": "Diagnostics for imports that have no corresponding imported python file or type stub file.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportMissingModuleSource": {
+          "type": "string",
+          "description": "Diagnostics for imports that have no corresponding source file. This happens when a type stub is found, but the module source file was not found, indicating that the code may fail at runtime when using this execution environment. Type checking will be done using the type stub.",
+          "default": "warning",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportMissingTypeStubs": {
+          "type": "string",
+          "description": "Diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). The type checker requires type stubs to do its best job at analysis.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportImportCycles": {
+          "type": "string",
+          "description": "Diagnostics for cyclical import chains. These are not errors in Python, but they do slow down type analysis and often hint at architectural layering issues. Generally, they should be avoided.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnusedImport": {
+          "type": "string",
+          "description": "Diagnostics for an imported symbol that is not referenced within that file.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnusedClass": {
+          "type": "string",
+          "description": "Diagnostics for a class with a private name (starting with an underscore) that is not accessed.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnusedFunction": {
+          "type": "string",
+          "description": "Diagnostics for a function or method with a private name (starting with an underscore) that is not accessed.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnusedVariable": {
+          "type": "string",
+          "description": "Diagnostics for a variable that is not accessed.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportDuplicateImport": {
+          "type": "string",
+          "description": "Diagnostics for an imported symbol or module that is imported more than once.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportWildcardImportFromLibrary": {
+          "type": "string",
+          "description": "Diagnostics for an wildcard import from an external library.",
+          "default": "warning",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportOptionalSubscript": {
+          "type": "string",
+          "description": "Diagnostics for an attempt to subscript (index) a variable with an Optional type.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportOptionalMemberAccess": {
+          "type": "string",
+          "description": "Diagnostics for an attempt to access a member of a variable with an Optional type.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportOptionalCall": {
+          "type": "string",
+          "description": "Diagnostics for an attempt to call a variable with an Optional type.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportOptionalIterable": {
+          "type": "string",
+          "description": "Diagnostics for an attempt to use an Optional type as an iterable value (e.g. within a for statement).",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportOptionalContextManager": {
+          "type": "string",
+          "description": "Diagnostics for an attempt to use an Optional type as a context manager (as a parameter to a with statement).",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportOptionalOperand": {
+          "type": "string",
+          "description": "Diagnostics for an attempt to use an Optional type as an operand to a binary or unary operator (like '+', '==', 'or', 'not').",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportTypedDictNotRequiredAccess": {
+          "type": "string",
+          "description": "Diagnostics for an attempt to access a non-required key within a TypedDict without a check for its presence.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUntypedFunctionDecorator": {
+          "type": "string",
+          "description": "Diagnostics for function decorators that have no type annotations. These obscure the function type, defeating many type analysis features.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUntypedClassDecorator": {
+          "type": "string",
+          "description": "Diagnostics for class decorators that have no type annotations. These obscure the class type, defeating many type analysis features.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUntypedBaseClass": {
+          "type": "string",
+          "description": "Diagnostics for base classes whose type cannot be determined statically. These obscure the class type, defeating many type analysis features.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUntypedNamedTuple": {
+          "type": "string",
+          "description": "Diagnostics when “namedtuple” is used rather than “NamedTuple”. The former contains no type information, whereas the latter does.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportPrivateUsage": {
+          "type": "string",
+          "description": "Diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore _ and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportTypeCommentUsage": {
+          "type": "string",
+          "description": "Diagnostics for usage of deprecated type comments.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportPrivateImportUsage": {
+          "type": "string",
+          "description": "Diagnostics for incorrect usage of symbol imported from a \"py.typed\" module that is not re-exported from that module.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportConstantRedefinition": {
+          "type": "string",
+          "description": "Diagnostics for attempts to redefine variables whose names are all-caps with underscores and numerals.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportDeprecated": {
+          "type": "string",
+          "description": "Diagnostics for use of deprecated classes or functions.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportIncompatibleMethodOverride": {
+          "type": "string",
+          "description": "Diagnostics for methods that override a method of the same name in a base class in an incompatible manner (wrong number of parameters, incompatible parameter types, or incompatible return type).",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportIncompatibleVariableOverride": {
+          "type": "string",
+          "description": "Diagnostics for overrides in subclasses that redefine a variable in an incompatible way.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportInconsistentConstructor": {
+          "type": "string",
+          "description": "Diagnostics for __init__ and __new__ methods whose signatures are inconsistent.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportOverlappingOverload": {
+          "type": "string",
+          "description": "Diagnostics for function overloads that overlap in signature and obscure each other or have incompatible return types.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportMissingSuperCall": {
+          "type": "string",
+          "description": "Diagnostics for missing call to parent class for inherited `__init__` methods.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUninitializedInstanceVariable": {
+          "type": "string",
+          "description": "Diagnostics for instance variables that are not declared or initialized within class body or `__init__` method.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportInvalidStringEscapeSequence": {
+          "type": "string",
+          "description": "Diagnostics for invalid escape sequences used within string literals. The Python specification indicates that such sequences will generate a syntax error in future versions.",
+          "default": "warning",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnknownParameterType": {
+          "type": "string",
+          "description": "Diagnostics for input or return parameters for functions or methods that have an unknown type.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnknownArgumentType": {
+          "type": "string",
+          "description": "Diagnostics for call arguments for functions or methods that have an unknown type.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnknownLambdaType": {
+          "type": "string",
+          "description": "Diagnostics for input or return parameters for lambdas that have an unknown type.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnknownVariableType": {
+          "type": "string",
+          "description": "Diagnostics for variables that have an unknown type..",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnknownMemberType": {
+          "type": "string",
+          "description": "Diagnostics for class or instance variables that have an unknown type.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportMissingParameterType": {
+          "type": "string",
+          "description": "Diagnostics for parameters that are missing a type annotation.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportMissingTypeArgument": {
+          "type": "string",
+          "description": "Diagnostics for generic class reference with missing type arguments.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportInvalidTypeVarUse": {
+          "type": "string",
+          "description": "Diagnostics for improper use of type variables in a function signature.",
+          "default": "warning",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportCallInDefaultInitializer": {
+          "type": "string",
+          "description": "Diagnostics for function calls within a default value initialization expression. Such calls can mask expensive operations that are performed at module initialization time.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnnecessaryIsInstance": {
+          "type": "string",
+          "description": "Diagnostics for 'isinstance' or 'issubclass' calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnnecessaryCast": {
+          "type": "string",
+          "description": "Diagnostics for 'cast' calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnnecessaryComparison": {
+          "type": "string",
+          "description": "Diagnostics for '==' and '!=' comparisons that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnnecessaryContains": {
+          "type": "string",
+          "description": "Diagnostics for 'in' operation that is statically determined to be unnecessary. Such operations are sometimes indicative of a programming error.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportAssertAlwaysTrue": {
+          "type": "string",
+          "description": "Diagnostics for 'assert' statement that will provably always assert. This can be indicative of a programming error.",
+          "default": "warning",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportSelfClsParameterName": {
+          "type": "string",
+          "description": "Diagnostics for a missing or misnamed “self” parameter in instance methods and “cls” parameter in class methods. Instance methods in metaclasses (classes that derive from “type”) are allowed to use “cls” for instance methods.",
+          "default": "warning",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportImplicitStringConcatenation": {
+          "type": "string",
+          "description": "Diagnostics for two or more string literals that follow each other, indicating an implicit concatenation. This is considered a bad practice and often masks bugs such as missing commas.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportInvalidStubStatement": {
+          "type": "string",
+          "description": "Diagnostics for type stub statements that do not conform to PEP 484.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportIncompleteStub": {
+          "type": "string",
+          "description": "Diagnostics for the use of a module-level “__getattr__” function, indicating that the stub is incomplete.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUndefinedVariable": {
+          "type": "string",
+          "description": "Diagnostics for undefined variables.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnboundVariable": {
+          "type": "string",
+          "description": "Diagnostics for unbound and possibly unbound variables.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnsupportedDunderAll": {
+          "type": "string",
+          "description": "Diagnostics for unsupported operations performed on __all__.",
+          "default": "warning",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnusedCallResult": {
+          "type": "string",
+          "description": "Diagnostics for call expressions whose results are not consumed and are not None.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnusedCoroutine": {
+          "type": "string",
+          "description": "Diagnostics for call expressions that return a Coroutine and whose results are not consumed.",
+          "default": "error",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnusedExpression": {
+          "type": "string",
+          "description": "Diagnostics for simple expressions whose value is not used in any way.",
+          "default": "warning",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportUnnecessaryTypeIgnoreComment": {
+          "type": "string",
+          "description": "Diagnostics for '# type: ignore' comments that have no effect.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportMatchNotExhaustive": {
+          "type": "string",
+          "description": "Diagnostics for 'match' statements that do not exhaustively match all possible values.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportShadowedImports": {
+          "type": "string",
+          "description": "Diagnostics for files that are overriding a module in the stdlib.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
+        },
+        "reportImplicitOverride": {
+          "type": "string",
+          "description": "Diagnostics for overridden methods that do not include an `@override` decorator.",
+          "default": "none",
+          "enum": ["none", "information", "warning", "error"]
         }
       }
+    },
+    "python.analysis.logLevel": {
+      "type": "string",
+      "default": "Information",
+      "description": "Specifies the level of logging for the Output panel",
+      "enum": ["Error", "Warning", "Information", "Trace"]
+    },
+    "python.analysis.typeCheckingMode": {
+      "type": "string",
+      "default": "basic",
+      "enum": ["off", "basic", "strict"],
+      "description": "Defines the default rule set for type checking.",
+      "scope": "resource"
+    },
+    "python.analysis.typeshedPaths": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "description": "Paths to look for typeshed modules.",
+      "scope": "resource"
+    },
+    "python.analysis.useLibraryCodeForTypes": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use library implementations to extract type information when type stub is not present.",
+      "scope": "resource"
+    },
+    "pyright.disableLanguageServices": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disables type completion, definitions, and references.",
+      "scope": "resource"
+    },
+    "pyright.disableOrganizeImports": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disables the “Organize Imports” command.",
+      "scope": "resource"
+    },
+    "python.pythonPath": {
+      "type": "string",
+      "default": "python",
+      "description": "Path to Python, you can use a custom version of Python.",
+      "scope": "resource"
+    },
+    "python.venvPath": {
+      "type": "string",
+      "default": "",
+      "description": "Path to folder with a list of Virtual Environments.",
+      "scope": "resource"
     }
   }
 }


### PR DESCRIPTION
## References

Fixes #918

## Code changes

- include defaults from overrides (provieded via schema) in composite defaults
- update/fix pyright schema (addressing warning in check added with above checking for defaults not aligning with schema)

## User-facing changes

- `overrides.json` will work
- pyright settings from UI will work

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
