### PR TITLE
Fix contrast of mark highlights in dark mode

### DIFF
--- a/packages/jupyterlab-lsp/style/signature.css
+++ b/packages/jupyterlab-lsp/style/signature.css
@@ -1,3 +1,13 @@
-.lsp-signature-help pre code {
+.lsp-signature-help code {
   font-size: var(--jp-code-font-size);
+}
+
+.lsp-signature-help code > mark {
+  color: var(--jp-lsp-signature-mark-color);
+  background: var(--jp-lsp-signature-mark-background);
+}
+
+.lsp-signature-help code > mark > span {
+  /* override syntax highlight colour to ensure contrast */
+  color: var(--jp-lsp-signature-mark-color) !important;
 }

--- a/packages/jupyterlab-lsp/style/variables/base.css
+++ b/packages/jupyterlab-lsp/style/variables/base.css
@@ -18,4 +18,7 @@
   /* hover */
   --jp-editor-mirror-lsp-hover-decoration-style: dotted;
   --jp-editor-mirror-lsp-hover-decoration-color: var(--jp-brand-color1);
+  /* signature */
+  --jp-lsp-signature-mark-color: black;
+  --jp-lsp-signature-mark-background: yellow;
 }

--- a/packages/jupyterlab-lsp/style/variables/jupyterlab-dark.css
+++ b/packages/jupyterlab-lsp/style/variables/jupyterlab-dark.css
@@ -1,3 +1,8 @@
 body[data-jp-theme-light='false'] .cm-s-jupyter {
   --jp-editor-mirror-lsp-highlight-background-color: rgba(151, 173, 255, 0.3);
 }
+
+body[data-jp-theme-light='false'] {
+  --jp-lsp-signature-mark-color: white;
+  --jp-lsp-signature-mark-background: #607e01;
+}


### PR DESCRIPTION
## References

Fixes https://github.com/jupyter-lsp/jupyterlab-lsp/issues/792

## Code changes

Adds `--jp-lsp-signature-mark-background` and `--jp-lsp-signature-mark-color` variables.

## User-facing changes

Uses a shade of green for highlight in dark mode. I am open to better colour choice suggestions!

Light mode

![Screenshot from 2023-04-16 15-43-42](https://user-images.githubusercontent.com/5832902/232320892-ff350932-5e5d-4015-9d80-37f6b6524308.png)

Dark mode

![Screenshot from 2023-04-16 15-43-50](https://user-images.githubusercontent.com/5832902/232320887-ca2215af-56c4-4755-b8a5-2e2a42e0d9b7.png)

## Backwards-incompatible changes

None