### PR TITLE
Limit the shadow FS initialisation to three attempts

### DIFF
--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_virtual_documents_shadow.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_virtual_documents_shadow.py
@@ -1,5 +1,4 @@
 import logging
-import stat
 from pathlib import Path
 from types import SimpleNamespace
 from typing import List

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_virtual_documents_shadow.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_virtual_documents_shadow.py
@@ -213,7 +213,8 @@ async def test_shadow_failures(shadow_path, manager):
 @pytest.fixture
 def forbidden_shadow_path(tmpdir):
     path = Path(tmpdir) / "no_permission_dir"
-    path.mkdir(mode=0)
+    path.mkdir()
+    path.chmod(0o000)
 
     yield path
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
@@ -2,6 +2,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from shutil import rmtree
+from typing import List
 
 from tornado.concurrent import run_on_executor
 from tornado.gen import convert_yielded
@@ -111,7 +112,7 @@ def setup_shadow_filesystem(virtual_documents_uri: str):
         )
 
     initialized = False
-    failures = []
+    failures: List[Exception] = []
 
     shadow_filesystem = Path(file_uri_to_path(virtual_documents_uri))
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
@@ -111,6 +111,8 @@ def setup_shadow_filesystem(virtual_documents_uri: str):
         )
 
     initialized = False
+    failures = []
+
     shadow_filesystem = Path(file_uri_to_path(virtual_documents_uri))
 
     @lsp_message_listener("client")
@@ -145,12 +147,27 @@ def setup_shadow_filesystem(virtual_documents_uri: str):
 
         # initialization (/any file system operations) delayed until needed
         if not initialized:
-            # create if does no exist (so that removal does not raise)
-            shadow_filesystem.mkdir(parents=True, exist_ok=True)
-            # remove with contents
-            rmtree(str(shadow_filesystem))
-            # create again
-            shadow_filesystem.mkdir(parents=True, exist_ok=True)
+            if len(failures) == 3:
+                return
+            try:
+                # create if does no exist (so that removal does not raise)
+                shadow_filesystem.mkdir(parents=True, exist_ok=True)
+                # remove with contents
+                rmtree(str(shadow_filesystem))
+                # create again
+                shadow_filesystem.mkdir(parents=True, exist_ok=True)
+            except (OSError, PermissionError, FileNotFoundError) as e:
+                failures.append(e)
+                if len(failures) == 3:
+                    manager.log.warn(
+                        "[lsp] initialization of shadow filesystem failed three times"
+                        " check if the path set by `LanguageServerManager.virtual_documents_dir`"
+                        " or `JP_LSP_VIRTUAL_DIR` is correct; if this is happening with a server"
+                        " for which which you control (or wish to override) jupyter-lsp specification"
+                        " you can try switching `requires_documents_on_disk` off. The errors were: %s",
+                        failures,
+                    )
+                return
             initialized = True
 
         path = file_uri_to_path(uri)


### PR DESCRIPTION
## References

Addresses https://github.com/jupyter-lsp/jupyterlab-lsp/issues/924#issuecomment-1531183986

## Code changes

- limit the shadow FS initialisation to three attempts
- emit a warning with suggestions if third attempt fails
- add a test for permission error

## User-facing changes

None unless affected by https://github.com/jupyter-lsp/jupyterlab-lsp/issues/924

## Backwards-incompatible changes

None