### PR TITLE
Await sleep coroutine while waiting for manager to be ready

### DIFF
--- a/python_packages/jupyter_lsp/jupyter_lsp/manager.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/manager.py
@@ -127,7 +127,7 @@ class LanguageServerManager(LanguageServerManagerAPI):
 
     async def ready(self):
         while not self._ready:  # pragma: no cover
-            asyncio.sleep(0.1)
+            await asyncio.sleep(0.1)
         return True
 
     def init_language_servers(self) -> None:


### PR DESCRIPTION

## References

In jupyter-lsp 2.1.0, when I open the jupyterlab page, the terminal give me a warning

```
/root/miniconda3/lib/python3.8/site-packages/jupyter_lsp/manager.py:130: RuntimeWarning: coroutine 'sleep' was never awaited
  asyncio.sleep(0.1)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

And then the process is stuck (and cpu 100%).

I notice that the coroutine `asyncio.sleep` is not sleeped here and it should be fixed.

https://github.com/jupyter-lsp/jupyterlab-lsp/blob/fee5ce6de8da23c9d00eb201d305a120a5e747a3/python_packages/jupyter_lsp/jupyter_lsp/manager.py#L128-L131

## Code changes



I add a `await` before `asyncio.sleep(0.1)` to fix it.
