### PR TITLE
Add `ignoreSeverities` setting

### DIFF
--- a/packages/jupyterlab-lsp/schema/diagnostics.json
+++ b/packages/jupyterlab-lsp/schema/diagnostics.json
@@ -30,6 +30,17 @@
       "default": [],
       "description": "Regular expressions matching messages of diagnostics which should not be shown in the panel nor highlighted in the editor."
     },
+    "ignoreSeverities": {
+      "title": "Diagnostic severity levels to ignore",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["Error", "Warning", "Information", "Hint"]
+      },
+      "default": [],
+      "uniqueItems": true,
+      "description": "Severities of diagnostics which should not be shown in the panel nor highlighted in the editor."
+    },
     "disable": {
       "title": "Disable",
       "type": "boolean",

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
@@ -12,18 +12,24 @@ import {
   set_notebook_content,
   showAllCells
 } from '../../editor_integration/testutils';
+import { DiagnosticSeverity } from '../../lsp';
 import { is_equal } from '../../positioning';
 import { foreign_code_extractors } from '../../transclusions/ipython/extractors';
 
 import { DiagnosticsCM, diagnostics_panel } from './diagnostics';
 import { message_without_code } from './listing';
 
+const SETTING_DEFAULTS: LSPDiagnosticsSettings = {
+  ignoreCodes: [],
+  ignoreMessagesPatterns: [],
+  ignoreSeverities: [],
+  defaultSeverity: 'Warning'
+};
+
 describe('Diagnostics', () => {
   let feature: DiagnosticsCM;
-  let default_settings = new MockSettings<LSPDiagnosticsSettings>({
-    defaultSeverity: 'Warning',
-    ignoreCodes: [],
-    ignoreMessagesPatterns: []
+  let defaultSettings = new MockSettings<LSPDiagnosticsSettings>({
+    ...SETTING_DEFAULTS
   });
 
   describe('FileEditor integration', () => {
@@ -34,7 +40,7 @@ describe('Diagnostics', () => {
       feature = env.init_integration({
         constructor: DiagnosticsCM,
         id: 'Diagnostics',
-        settings: default_settings
+        settings: defaultSettings
       });
     });
     afterEach(() => {
@@ -47,14 +53,15 @@ describe('Diagnostics', () => {
       expect(feature.is_registered).to.equal(true);
     });
 
-    const diagnostics = [
+    const diagnostics: lsProtocol.Diagnostic[] = [
       {
         range: {
           start: { line: 0, character: 7 },
           end: { line: 0, character: 9 }
         },
         message: 'Undefined symbol "aa"',
-        code: 'E001'
+        code: 'E001',
+        severity: DiagnosticSeverity['Error']
       },
       {
         range: {
@@ -62,7 +69,8 @@ describe('Diagnostics', () => {
           end: { line: 1, character: 4 }
         },
         message: 'Trimming whitespace',
-        code: 'W001'
+        code: 'W001',
+        severity: DiagnosticSeverity['Warning']
       }
     ];
 
@@ -91,9 +99,32 @@ describe('Diagnostics', () => {
         constructor: DiagnosticsCM,
         id: 'Diagnostics',
         settings: new MockSettings({
-          defaultSeverity: 'Warning',
-          ignoreCodes: ['W001'],
-          ignoreMessagesPatterns: []
+          ...SETTING_DEFAULTS,
+          ignoreCodes: ['W001']
+        })
+      });
+      env.ce_editor.model.value.text = text;
+      await env.adapter.update_documents();
+
+      feature.handleDiagnostic(null as any, {
+        uri: env.document_options.path,
+        diagnostics: diagnostics
+      });
+
+      let markers = env.ce_editor.editor.getDoc().getAllMarks();
+      expect(markers.length).to.equal(1);
+      expect((markers[0] as TextMarkerOptions).title).to.equal(
+        'Undefined symbol "aa"'
+      );
+    });
+
+    it('filters out inspections by severity', async () => {
+      feature = env.init_integration({
+        constructor: DiagnosticsCM,
+        id: 'Diagnostics',
+        settings: new MockSettings({
+          ...SETTING_DEFAULTS,
+          ignoreSeverities: ['Warning']
         })
       });
       env.ce_editor.model.value.text = text;
@@ -116,8 +147,7 @@ describe('Diagnostics', () => {
         constructor: DiagnosticsCM,
         id: 'Diagnostics',
         settings: new MockSettings({
-          defaultSeverity: 'Warning',
-          ignoreCodes: [],
+          ...SETTING_DEFAULTS,
           ignoreMessagesPatterns: ['Undefined symbol "\\w+"']
         })
       });
@@ -148,7 +178,7 @@ describe('Diagnostics', () => {
       feature = env.init_integration({
         constructor: DiagnosticsCM,
         id: 'Diagnostics',
-        settings: default_settings
+        settings: defaultSettings
       });
     });
     afterEach(() => {
@@ -266,7 +296,7 @@ describe('Diagnostics', () => {
         constructor: DiagnosticsCM,
         id: 'Diagnostics',
         document: foreign_document,
-        settings: default_settings
+        settings: defaultSettings
       });
 
       let response = {

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -445,6 +445,11 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
     const ignoredDiagnosticsCodes = new Set(
       this.settings.composite.ignoreCodes
     );
+    const ignoredSeverities = new Set<number>(
+      this.settings.composite.ignoreSeverities.map(
+        severityName => DiagnosticSeverity[severityName]
+      )
+    );
     const ignoredMessagesRegExp =
       this.settings.composite.ignoreMessagesPatterns.map(
         pattern => new RegExp(pattern)
@@ -462,6 +467,10 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
         code !== null &&
         ignoredDiagnosticsCodes.has(code.toString())
       ) {
+        return false;
+      }
+      let severity = diagnostic.severity;
+      if (severity && ignoredSeverities.has(severity)) {
         return false;
       }
       let message = diagnostic.message;


### PR DESCRIPTION
## References

Closes #751

## Code changes

Adds `ignoreSeverities` setting

## User-facing changes

New setting:

![Screenshot from 2023-05-28 12-28-02](https://github.com/jupyter-lsp/jupyterlab-lsp/assets/5832902/9685e75c-46f7-482d-87e4-46b5542e2447)


## Backwards-incompatible changes

None