### PR TITLE
Prepare jupyterlab-lsp 4.2.0 and jupyter-lsp 2.2.0 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Changelog
 
+### `@jupyter-lsp/jupyterlab-lsp 4.2.0` (2023-05-28)
+
+- features:
+  - diagnostics can be ignored by severity level with new `ignoreSeverities` setting ([#940])
+
+### `jupyter-lsp 2.2.0` (2023-05-28)
+
+- bug fixes:
+  - await `sleep()` coroutine ([#939], thanks @jinzhen-lin)
+  - limit attempts to initialise shadow file system to three trials ([#936])
+- maintenance:
+  - support `bash-language-sever` 4.3.2+ ([#938], thanks @ackalker)
+
+[#936]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/936
+[#938]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/938
+[#939]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/939
+[#940]: https://github.com/jupyter-lsp/jupyterlab-lsp/pull/940
+
 ### `@jupyter-lsp/jupyterlab-lsp 4.1.0` (2023-04-24)
 
 - features:

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-lsp/jupyterlab-lsp",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-lsp/jupyterlab-lsp-metapackage",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/jupyter-lsp/jupyterlab-lsp",
   "bugs": {

--- a/python_packages/jupyter_lsp/jupyter_lsp/_version.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/_version.py
@@ -1,3 +1,3 @@
 """ single source of truth for jupyter_lsp version
 """
-__version__ = "2.1.0"
+__version__ = "2.2.0"


### PR DESCRIPTION
Small changeset this time, possibly last point release before switching gears toward 5.0 rewrite/JupyterLab 4.0 compatibility (help wanted)