### PR TITLE
fix: handle CORS OPTIONS request

### DIFF
--- a/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
@@ -75,6 +75,21 @@ class LanguageServersHandler(BaseHandler):
 
         self.finish(response)
 
+    def options(self, *args, **kwargs):
+        """Get the options."""
+        self.log.warning("handle options request: %s", self.request.path)
+        if "Access-Control-Allow-Headers" in self.settings.get("headers", {}):
+            self.set_header(
+                "Access-Control-Allow-Headers",
+                self.settings["headers"]["Access-Control-Allow-Headers"],
+            )
+        else:
+            self.set_header(
+                "Access-Control-Allow-Headers",
+                "accept, content-type, authorization, x-xsrftoken",
+            )
+        self.set_header("Access-Control-Allow-Methods", "GET, PUT, POST, PATCH, DELETE, OPTIONS")
+
 
 def add_handlers(nbapp):
     """Add Language Server routes to the notebook server web application"""

--- a/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
@@ -2,7 +2,7 @@
 """
 from typing import Optional, Text
 
-from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.base.handlers import APIHandler
 from jupyter_server.base.zmqhandlers import WebSocketHandler, WebSocketMixin
 from jupyter_server.utils import url_path_join as ujoin
 
@@ -11,7 +11,7 @@ from .schema import SERVERS_RESPONSE
 from .specs.utils import censored_spec
 
 
-class BaseHandler(JupyterHandler):
+class BaseHandler(APIHandler):
     manager = None  # type: LanguageServerManager
 
     def initialize(self, manager: LanguageServerManager):
@@ -74,21 +74,6 @@ class LanguageServersHandler(BaseHandler):
             self.log.warning("{} validation errors: {}".format(len(errors), errors))
 
         self.finish(response)
-
-    def options(self, *args, **kwargs):
-        """Get the options."""
-        self.log.warning("handle options request: %s", self.request.path)
-        if "Access-Control-Allow-Headers" in self.settings.get("headers", {}):
-            self.set_header(
-                "Access-Control-Allow-Headers",
-                self.settings["headers"]["Access-Control-Allow-Headers"],
-            )
-        else:
-            self.set_header(
-                "Access-Control-Allow-Headers",
-                "accept, content-type, authorization, x-xsrftoken",
-            )
-        self.set_header("Access-Control-Allow-Methods", "GET, PUT, POST, PATCH, DELETE, OPTIONS")
 
 
 def add_handlers(nbapp):


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

when deploy jupyter-lsp on server, the GET request may need handle the CORS problem, which means handle OPTIONS request properly.

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above).
Use "fixes" and "closes" linking phrases as appropriate. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- handle CORS Options request in the same way with jupyter-server

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [ ] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
