### PR TITLE
Reformat to `camelCase`, enable `no-empty-interface` rule

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# enable camelCase
+79920f498ebc426b6df47c387c410df21a8a5e6c

--- a/packages/.eslintrc.js
+++ b/packages/.eslintrc.js
@@ -58,7 +58,7 @@ module.exports = {
     ],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-empty-interface': 'off',
+    '@typescript-eslint/no-empty-interface': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: true }],
     '@typescript-eslint/no-inferrable-types': 'off',

--- a/packages/.eslintrc.js
+++ b/packages/.eslintrc.js
@@ -34,7 +34,28 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'jest', 'import'],
   rules: {
-    '@typescript-eslint/camelcase': 'off',
+    camelcase: [
+      'error',
+      {
+        ignoreGlobals: true,
+        allow: [
+          'cell_type',
+          'execution_count',
+          'language_info',
+          'nbconvert_exporter',
+          'pygments_lexer',
+          'codemirror_mode',
+          'orig_nbformat',
+          'display_name',
+          'language_servers',
+          'cm_to_ce',
+          'lsp_to_ce',
+          'ce_to_cm',
+          'cm_to_lsp',
+          'lsp_to_cm'
+        ]
+      }
+    ],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-empty-interface': 'off',

--- a/packages/code-jumpers/src/jumpers/fileeditor.ts
+++ b/packages/code-jumpers/src/jumpers/fileeditor.ts
@@ -13,13 +13,13 @@ export class FileEditorJumper extends CodeJumper {
   widget: IDocumentWidget;
 
   constructor(
-    editor_widget: IDocumentWidget<FileEditor>,
-    document_manager: IDocumentManager
+    editorWidget: IDocumentWidget<FileEditor>,
+    documentManager: IDocumentManager
   ) {
     super();
-    this.widget = editor_widget;
-    this.document_manager = document_manager;
-    this.editor = editor_widget.content;
+    this.widget = editorWidget;
+    this.documentManager = documentManager;
+    this.editor = editorWidget.content;
     this.history = new JumpHistory();
   }
 
@@ -31,8 +31,8 @@ export class FileEditorJumper extends CodeJumper {
     return [this.editor.editor];
   }
 
-  jump(jump_position: ILocalPosition) {
-    let { token } = jump_position;
+  jump(jumpPosition: ILocalPosition) {
+    let { token } = jumpPosition;
 
     // TODO: this is common
     // place cursor in the line with the definition
@@ -58,11 +58,11 @@ export class FileEditorJumper extends CodeJumper {
   getCurrentPosition(): IGlobalPosition {
     let position = this.editor.editor.getCursorPosition();
     return {
-      editor_index: 0,
+      editorIndex: 0,
       line: position.line,
       column: position.column,
-      contents_path: this.editor.context.path,
-      is_symlink: false
+      contentsPath: this.editor.context.path,
+      isSymlink: false
     };
   }
 }

--- a/packages/code-jumpers/src/jumpers/jumper.ts
+++ b/packages/code-jumpers/src/jumpers/jumper.ts
@@ -8,7 +8,7 @@ import { FileEditor } from '@jupyterlab/fileeditor';
 import { JumpHistory } from '../history';
 import { IGlobalPosition, ILocalPosition } from '../positions';
 
-const movement_keys = [
+const movementKeys = [
   'ArrowRight',
   'ArrowLeft',
   'ArrowUp',
@@ -21,7 +21,7 @@ const movement_keys = [
 
 const modifiers = ['Alt', 'AltGraph', 'Control', 'Shift'];
 
-const system_keys = [
+const systemKeys = [
   'F1',
   'F2',
   'F3',
@@ -38,66 +38,66 @@ const system_keys = [
 ];
 
 export abstract class CodeJumper {
-  document_manager: IDocumentManager;
+  documentManager: IDocumentManager;
   widget: IDocumentWidget;
 
   history: JumpHistory;
 
   abstract get editors(): ReadonlyArray<CodeEditor.IEditor>;
 
-  private go_to_position(
-    document_widget: IDocumentWidget,
+  private goToPosition(
+    documentWidget: IDocumentWidget,
     jumper: string,
     column: number,
-    line_number: number,
-    input_number = 0
+    lineNumber: number,
+    inputNumber = 0
   ) {
-    let document_jumper: CodeJumper;
-    let position = { line: line_number, column: column };
-    let document_jumper_type = jumpers.get(jumper);
+    let documentJumper: CodeJumper;
+    let position = { line: lineNumber, column: column };
+    let documentJumperType = jumpers.get(jumper);
 
-    document_jumper = new document_jumper_type(
-      document_widget,
-      this.document_manager
+    documentJumper = new documentJumperType(
+      documentWidget,
+      this.documentManager
     );
-    let jump_position = document_jumper.getJumpPosition(position, input_number);
-    document_jumper.jump(jump_position);
+    let jumpPosition = documentJumper.getJumpPosition(position, inputNumber);
+    documentJumper.jump(jumpPosition);
   }
 
-  private _global_jump(position: IGlobalPosition) {
-    let document_widget = this.document_manager.openOrReveal(
-      position.contents_path
+  private _globalJump(position: IGlobalPosition) {
+    let documentWidget = this.documentManager.openOrReveal(
+      position.contentsPath
     );
-    if (!document_widget) {
+    if (!documentWidget) {
       console.log('Widget failed to open for jump');
       return;
     }
-    let is_symlink = position.is_symlink;
+    let isSymlink = position.isSymlink;
 
-    document_widget.revealed
+    documentWidget.revealed
       .then(() => {
-        this.go_to_position(
-          document_widget!,
-          position.contents_path.endsWith('.ipynb') ? 'notebook' : 'fileeditor',
+        this.goToPosition(
+          documentWidget!,
+          position.contentsPath.endsWith('.ipynb') ? 'notebook' : 'fileeditor',
           position.column,
           position.line,
-          position.editor_index
+          position.editorIndex
         );
 
         // protect external files from accidental edition
-        if (is_symlink) {
-          this.protectFromAccidentalEditing(document_widget!);
+        if (isSymlink) {
+          this.protectFromAccidentalEditing(documentWidget!);
         }
       })
       .catch(console.warn);
   }
 
-  private protectFromAccidentalEditing(document_widget: IDocumentWidget) {
-    let editor_widget = document_widget as IDocumentWidget<FileEditor>;
-    // We used to adjust `editor_widget.title.label` here but an upstream
+  private protectFromAccidentalEditing(documentWidget: IDocumentWidget) {
+    let editorWidget = documentWidget as IDocumentWidget<FileEditor>;
+    // We used to adjust `editorWidget.title.label` here but an upstream
     // bug (https://github.com/jupyterlab/jupyterlab/issues/10856) prevents
     // us from doing so anymore.
-    let editor = editor_widget.content.editor;
+    let editor = editorWidget.content.editor;
     let active = true;
     editor.injectExtension(
       EditorView.domEventHandlers({
@@ -107,9 +107,9 @@ export abstract class CodeJumper {
           }
           // allow to move around, select text and use modifiers & browser keys freely
           if (
-            movement_keys.indexOf(event.key) !== -1 ||
+            movementKeys.indexOf(event.key) !== -1 ||
             modifiers.indexOf(event.key) !== -1 ||
-            system_keys.indexOf(event.key) !== -1
+            systemKeys.indexOf(event.key) !== -1
           ) {
             return false;
           }
@@ -120,7 +120,7 @@ export abstract class CodeJumper {
             return false;
           }
 
-          let dialog_promise = showDialog({
+          let dialogPromise = showDialog({
             title: 'Edit external file?',
             body:
               'This file is located outside of the root of the JupyterLab start directory. ' +
@@ -131,7 +131,7 @@ export abstract class CodeJumper {
             ]
           });
 
-          dialog_promise
+          dialogPromise
             .then(result => {
               if (result.button.accept) {
                 active = false;
@@ -148,17 +148,17 @@ export abstract class CodeJumper {
 
   protected abstract jump(position: ILocalPosition): void;
 
-  global_jump_back() {
-    let previous_position = this.history.recollect();
-    if (previous_position) {
-      this._global_jump(previous_position);
+  globalJumpBack() {
+    let previousPosition = this.history.recollect();
+    if (previousPosition) {
+      this._globalJump(previousPosition);
     }
   }
 
-  global_jump(position: IGlobalPosition) {
-    const current_position = this.getCurrentPosition();
-    this.history.store(current_position);
-    this._global_jump(position);
+  globalJump(position: IGlobalPosition) {
+    const currentPosition = this.getCurrentPosition();
+    this.history.store(currentPosition);
+    this._globalJump(position);
   }
 
   abstract getCurrentPosition(): IGlobalPosition;
@@ -167,7 +167,7 @@ export abstract class CodeJumper {
 
   abstract getJumpPosition(
     position: CodeEditor.IPosition,
-    input_number?: number
+    inputNumber?: number
   ): ILocalPosition;
 }
 

--- a/packages/code-jumpers/src/jumpers/notebook.ts
+++ b/packages/code-jumpers/src/jumpers/notebook.ts
@@ -13,14 +13,14 @@ export class NotebookJumper extends CodeJumper {
   widget: NotebookPanel;
 
   constructor(
-    notebook_widget: NotebookPanel,
-    document_manager: IDocumentManager
+    notebookWidget: NotebookPanel,
+    documentManager: IDocumentManager
   ) {
     super();
-    this.widget = notebook_widget;
-    this.notebook = notebook_widget.content;
+    this.widget = notebookWidget;
+    this.notebook = notebookWidget.content;
     this.history = new JumpHistory();
-    this.document_manager = document_manager;
+    this.documentManager = documentManager;
   }
 
   get editors() {
@@ -55,21 +55,21 @@ export class NotebookJumper extends CodeJumper {
       this.editors[this.notebook.activeCellIndex].getCursorPosition();
 
     return {
-      editor_index: this.notebook.activeCellIndex,
+      editorIndex: this.notebook.activeCellIndex,
       line: position.line,
       column: position.column,
-      contents_path: this.widget.context.path,
-      is_symlink: false
+      contentsPath: this.widget.context.path,
+      isSymlink: false
     };
   }
 
-  getJumpPosition(position: CodeEditor.IPosition, input_number: number) {
+  getJumpPosition(position: CodeEditor.IPosition, inputNumber: number) {
     return {
       token: {
-        offset: this.getOffset(position, input_number),
+        offset: this.getOffset(position, inputNumber),
         value: ''
       },
-      index: input_number
+      index: inputNumber
     };
   }
 }

--- a/packages/code-jumpers/src/positions.ts
+++ b/packages/code-jumpers/src/positions.ts
@@ -16,7 +16,7 @@ export interface IGlobalPosition {
   /**
    * In notebooks, the index of the target editor; 0 in widgets with single editor.
    */
-  editor_index: number;
+  editorIndex: number;
 
   line: number;
   column: number;
@@ -24,7 +24,7 @@ export interface IGlobalPosition {
   /**
    * The Jupyter ContentsManager path, _not_ passed through encode URI.
    */
-  contents_path: string;
+  contentsPath: string;
 
-  is_symlink: boolean;
+  isSymlink: boolean;
 }

--- a/packages/completion-theme/src/about.tsx
+++ b/packages/completion-theme/src/about.tsx
@@ -8,7 +8,7 @@ import {
   ILicenseInfo
 } from './types';
 
-function render_licence(licence: ILicenseInfo): ReactElement {
+function renderLicence(licence: ILicenseInfo): ReactElement {
   return (
     <div className={'lsp-licence'}>
       <a href={licence.link} title={licence.name}>
@@ -21,14 +21,14 @@ function render_licence(licence: ILicenseInfo): ReactElement {
 
 type IconSetGetter = (theme: ICompletionTheme) => Map<string, LabIcon>;
 
-function render_theme(
+function renderTheme(
   trans: TranslationBundle,
   theme: ICompletionTheme,
-  get_set: IconSetGetter,
-  is_current: boolean
+  getSet: IconSetGetter,
+  isCurrent: boolean
 ): ReactElement {
   let icons: ReactElement[] = [];
-  for (let [name, icon] of get_set(theme)) {
+  for (let [name, icon] of getSet(theme)) {
     icons.push(
       <div className={'lsp-completer-icon-row'}>
         <div>{name}</div>
@@ -44,7 +44,7 @@ function render_theme(
     >
       <h4>
         {theme.name}
-        {is_current ? trans.__(' (current)') : ''}
+        {isCurrent ? trans.__(' (current)') : ''}
       </h4>
       <ul>
         <li key={'id'}>
@@ -52,7 +52,7 @@ function render_theme(
         </li>
         <li key={'licence'}>
           {trans.__('Licence: ')}
-          {render_licence(theme.icons.licence)}
+          {renderLicence(theme.icons.licence)}
         </li>
         <li key={'dark'}>
           {typeof theme.icons.dark === 'undefined'
@@ -65,16 +65,16 @@ function render_theme(
   );
 }
 
-export function render_themes_list(
+export function renderThemesList(
   trans: TranslationBundle,
   props: {
     themes: ICompletionTheme[];
     current: ICompletionTheme | null;
-    get_set: IconSetGetter;
+    getSet: IconSetGetter;
   }
 ): React.ReactElement {
   let themes = props.themes.map(theme =>
-    render_theme(trans, theme, props.get_set, theme == props.current)
+    renderTheme(trans, theme, props.getSet, theme == props.current)
   );
   return <div>{themes}</div>;
 }

--- a/packages/completion-theme/src/types.ts
+++ b/packages/completion-theme/src/types.ts
@@ -107,17 +107,17 @@ export interface ICompletionTheme {
 }
 
 export interface ILSPCompletionThemeManager {
-  get_icon(type: string): LabIcon.ILabIcon | null;
+  getIcon(type: string): LabIcon.ILabIcon | null;
 
-  set_theme(theme_id: string | null): void;
+  setTheme(theme_id: string | null): void;
 
-  register_theme(theme: ICompletionTheme): void;
+  registerTheme(theme: ICompletionTheme): void;
 
-  get_iconset(
+  getIconSet(
     theme: ICompletionTheme
   ): Map<keyof ICompletionIconSet, LabIcon.ILabIcon>;
 
-  set_icons_overrides(
+  setIconsOverrides(
     map: Record<string, CompletionItemKindStrings | 'Kernel'>
   ): void;
 }

--- a/packages/jupyterlab-lsp/src/components/free_tooltip.ts
+++ b/packages/jupyterlab-lsp/src/components/free_tooltip.ts
@@ -195,7 +195,7 @@ export class EditorTooltipManager {
   private currentTooltip: FreeTooltip | null = null;
   private currentOptions: EditorTooltip.IOptions | null;
 
-  constructor(private rendermime_registry: IRenderMimeRegistry) {}
+  constructor(private rendermimeRegistry: IRenderMimeRegistry) {}
 
   create(options: EditorTooltip.IOptions): FreeTooltip {
     this.remove();
@@ -208,7 +208,7 @@ export class EditorTooltipManager {
       anchor: widget.content,
       bundle: bundle,
       editor: options.ceEditor,
-      rendermime: this.rendermime_registry,
+      rendermime: this.rendermimeRegistry,
       position: PositionConverter.cm_to_ce(position)
     });
     tooltip.addClass(CLASS_NAME);

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -235,26 +235,26 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
     this.addClass('lsp-popover');
   }
   render() {
-    if (!this.model?.connection_manager) {
+    if (!this.model?.connectionManager) {
       return null;
     }
-    const servers_available = this.model.servers_available_not_in_use.map(
+    const serversAvailable = this.model.serversAvailableNotInUse.map(
       (session, i) => <ServerStatus key={i} server={session} />
     );
 
-    let running_servers = new Array<any>();
+    let runningServers = new Array<any>();
     let key = -1;
     for (let [
       session,
-      documents_by_language
-    ] of this.model.documents_by_server.entries()) {
+      documentsByLanguage
+    ] of this.model.documentsByServer.entries()) {
       key += 1;
-      let documents_html = new Array<any>();
-      for (let [language, documents] of documents_by_language) {
+      let documentsHtml = new Array<any>();
+      for (let [language, documents] of documentsByLanguage) {
         // TODO: stop button
         // TODO: add a config buttons next to the language header
         let list = documents.map((document, i) => {
-          let connection = this.model.connection_manager.connections.get(
+          let connection = this.model.connectionManager.connections.get(
             document.uri
           );
 
@@ -287,7 +287,7 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
           );
         });
 
-        documents_html.push(
+        documentsHtml.push(
           <div key={key} className={'lsp-documents-by-language'}>
             <h5>
               {language}{' '}
@@ -300,59 +300,58 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
         );
       }
 
-      running_servers.push(<div key={key}>{documents_html}</div>);
+      runningServers.push(<div key={key}>{documentsHtml}</div>);
     }
 
-    const missing_languages = this.model.missing_languages.map(
-      (language, i) => {
-        const specs_for_missing =
-          this.model.language_server_manager.getMatchingSpecs({ language });
-        return (
-          <div key={i} className={'lsp-missing-server'}>
-            {language}
-            {specs_for_missing.size ? (
-              <HelpButton
-                language={language}
-                servers={specs_for_missing}
-                trans={this.model.trans}
-              />
-            ) : (
-              ''
-            )}
-          </div>
-        );
-      }
-    );
+    const missingLanguages = this.model.missingLanguages.map((language, i) => {
+      const specsForMissing = this.model.languageServerManager.getMatchingSpecs(
+        { language }
+      );
+      return (
+        <div key={i} className={'lsp-missing-server'}>
+          {language}
+          {specsForMissing.size ? (
+            <HelpButton
+              language={language}
+              servers={specsForMissing}
+              trans={this.model.trans}
+            />
+          ) : (
+            ''
+          )}
+        </div>
+      );
+    });
     const trans = this.model.trans;
     return (
       <div className={'lsp-popover-content'}>
         <div className={'lsp-servers-menu'}>
           <h3 className={'lsp-servers-title'}>{trans.__('LSP servers')}</h3>
           <div className={'lsp-servers-lists'}>
-            {servers_available.length ? (
+            {serversAvailable.length ? (
               <CollapsibleList
                 key={'available'}
                 title={trans.__('Available')}
-                list={servers_available}
+                list={serversAvailable}
                 startCollapsed={true}
               />
             ) : (
               ''
             )}
-            {running_servers.length ? (
+            {runningServers.length ? (
               <CollapsibleList
                 key={'running'}
                 title={trans.__('Running')}
-                list={running_servers}
+                list={runningServers}
               />
             ) : (
               ''
             )}
-            {missing_languages.length ? (
+            {missingLanguages.length ? (
               <CollapsibleList
                 key={'missing'}
                 title={trans.__('Missing')}
-                list={missing_languages}
+                list={missingLanguages}
               />
             ) : (
               ''
@@ -410,11 +409,11 @@ export class LSPStatus extends VDomRenderer<LSPStatus.Model> {
     return (
       <GroupItem
         spacing={this.displayText ? 2 : 0}
-        title={model.long_message}
+        title={model.longMessage}
         onClick={this.handleClick}
         className={'lsp-status-group'}
       >
-        <model.status_icon.react
+        <model.statusIcon.react
           top={'2px'}
           stylesheet={'statusBar'}
           title={this.trans.__('LSP Code Intelligence')}
@@ -422,7 +421,7 @@ export class LSPStatus extends VDomRenderer<LSPStatus.Model> {
         {this.displayText ? (
           <TextItem
             className={'lsp-status-message'}
-            source={model.short_message}
+            source={model.shortMessage}
           />
         ) : (
           <></>
@@ -435,7 +434,7 @@ export class LSPStatus extends VDomRenderer<LSPStatus.Model> {
     if (this._popup) {
       this._popup.dispose();
     }
-    if (this.model.status.status == 'no_server_extension') {
+    if (this.model.status.status == 'noServerExtension') {
       showDialog({
         title: this.trans.__('LSP server extension not found'),
         body: SERVER_EXTENSION_404,
@@ -473,9 +472,9 @@ export class StatusButtonExtension
       this.options.shell,
       this.options.translatorBundle
     );
-    statusBarItem.model.language_server_manager =
+    statusBarItem.model.languageServerManager =
       this.options.languageServerManager;
-    statusBarItem.model.connection_manager = this.options.connectionManager;
+    statusBarItem.model.connectionManager = this.options.connectionManager;
     return statusBarItem;
   }
 
@@ -495,22 +494,22 @@ export class StatusButtonExtension
 }
 
 type StatusCode =
-  | 'no_server_extension'
+  | 'noServerExtension'
   | 'waiting'
   | 'initializing'
   | 'initialized'
   | 'connecting'
-  | 'initialized_but_some_missing';
+  | 'initializedButSomeMissing';
 
 export interface IStatus {
-  connected_documents: Set<VirtualDocument>;
-  initialized_documents: Set<VirtualDocument>;
-  open_connections: Array<ILSPConnection>;
-  detected_documents: Set<VirtualDocument>;
+  connectedDocuments: Set<VirtualDocument>;
+  initializedDocuments: Set<VirtualDocument>;
+  openConnections: Array<ILSPConnection>;
+  detectedDocuments: Set<VirtualDocument>;
   status: StatusCode;
 }
 
-function collect_languages(virtualDocument: VirtualDocument): Set<string> {
+function collectLanguages(virtualDocument: VirtualDocument): Set<string> {
   let documents = collectDocuments(virtualDocument);
   return new Set(
     [...documents].map(document => document.language.toLocaleLowerCase())
@@ -521,20 +520,20 @@ type StatusMap = Record<StatusCode, string>;
 type StatusIconClass = Record<StatusCode, string>;
 
 const classByStatus: StatusIconClass = {
-  no_server_extension: 'error',
+  noServerExtension: 'error',
   waiting: 'inactive',
   initialized: 'ready',
   initializing: 'preparing',
-  initialized_but_some_missing: 'ready',
+  initializedButSomeMissing: 'ready',
   connecting: 'preparing'
 };
 
 const iconByStatus: Record<StatusCode, LabIcon> = {
-  no_server_extension: codeWarningIcon,
+  noServerExtension: codeWarningIcon,
   waiting: codeClockIcon,
   initialized: codeCheckIcon,
   initializing: codeClockIcon,
-  initialized_but_some_missing: codeWarningIcon,
+  initializedButSomeMissing: codeWarningIcon,
   connecting: codeClockIcon
 };
 
@@ -543,10 +542,9 @@ export namespace LSPStatus {
    * A VDomModel for the LSP of current file editor/notebook.
    */
   export class Model extends VDomModel {
-    server_extension_status: SCHEMA.ServersResponse | null = null;
-    language_server_manager: ILanguageServerManager;
+    languageServerManager: ILanguageServerManager;
     trans: TranslationBundle;
-    private _connection_manager: ILSPDocumentConnectionManager;
+    private _connectionManager: ILSPDocumentConnectionManager;
     private _shortMessageByStatus: StatusMap;
 
     constructor(
@@ -556,10 +554,10 @@ export namespace LSPStatus {
       super();
       this.trans = trans;
       this._shortMessageByStatus = {
-        no_server_extension: trans.__('Server extension missing'),
+        noServerExtension: trans.__('Server extension missing'),
         waiting: trans.__('Waiting…'),
         initialized: trans.__('Fully initialized'),
-        initialized_but_some_missing: trans.__(
+        initializedButSomeMissing: trans.__(
           'Initialized (additional servers needed)'
         ),
         initializing: trans.__('Initializing…'),
@@ -567,13 +565,13 @@ export namespace LSPStatus {
       };
     }
 
-    get available_servers(): TSessionMap {
-      return this.language_server_manager.sessions;
+    get availableServers(): TSessionMap {
+      return this.languageServerManager.sessions;
     }
 
-    get supported_languages(): Set<string> {
+    get supportedLanguages(): Set<string> {
       const languages = new Set<string>();
-      for (let server of this.available_servers.values()) {
+      for (let server of this.availableServers.values()) {
         for (let language of server.spec.languages!) {
           languages.add(language.toLocaleLowerCase());
         }
@@ -581,12 +579,12 @@ export namespace LSPStatus {
       return languages;
     }
 
-    private is_server_running(
+    private _isServerRunning(
       id: TLanguageServerId,
       server: SCHEMA.LanguageServerSession
     ): boolean {
-      for (const language of this.detected_languages) {
-        const matchedServers = this.language_server_manager.getMatchingServers({
+      for (const language of this.detectedLanguages) {
+        const matchedServers = this.languageServerManager.getMatchingServers({
           language
         });
         // TODO server.status === "started" ?
@@ -598,7 +596,7 @@ export namespace LSPStatus {
       return false;
     }
 
-    get documents_by_server(): Map<
+    get documentsByServer(): Map<
       SCHEMA.LanguageServerSession,
       Map<string, VirtualDocument[]>
     > {
@@ -610,132 +608,130 @@ export namespace LSPStatus {
         return data;
       }
 
-      let main_document = this.adapter.virtualDocument;
-      let documents = collectDocuments(main_document);
+      let mainDocument = this.adapter.virtualDocument;
+      let documents = collectDocuments(mainDocument);
 
       for (let document of documents.values()) {
         let language = document.language.toLocaleLowerCase();
-        let server_ids =
-          this._connection_manager.languageServerManager.getMatchingServers({
+        let serverIds =
+          this._connectionManager.languageServerManager.getMatchingServers({
             language: document.language
           });
-        if (server_ids.length === 0) {
+        if (serverIds.length === 0) {
           continue;
         }
         // For now only use the server with the highest priority
-        let server = this.language_server_manager.sessions.get(server_ids[0])!;
+        let server = this.languageServerManager.sessions.get(serverIds[0])!;
 
         if (!data.has(server)) {
           data.set(server, new Map<string, VirtualDocument[]>());
         }
 
-        let documents_map = data.get(server)!;
+        let documentsMap = data.get(server)!;
 
-        if (!documents_map.has(language)) {
-          documents_map.set(language, new Array<VirtualDocument>());
+        if (!documentsMap.has(language)) {
+          documentsMap.set(language, new Array<VirtualDocument>());
         }
 
-        let documents = documents_map.get(language)!;
+        let documents = documentsMap.get(language)!;
         documents.push(document);
       }
       return data;
     }
 
-    get servers_available_not_in_use(): Array<SCHEMA.LanguageServerSession> {
-      return [...this.available_servers.entries()]
-        .filter(([id, server]) => !this.is_server_running(id, server))
+    get serversAvailableNotInUse(): Array<SCHEMA.LanguageServerSession> {
+      return [...this.availableServers.entries()]
+        .filter(([id, server]) => !this._isServerRunning(id, server))
         .map(([id, server]) => server);
     }
 
-    get detected_languages(): Set<string> {
+    get detectedLanguages(): Set<string> {
       if (!this.adapter?.virtualDocument) {
         return new Set<string>();
       }
 
       let document = this.adapter.virtualDocument;
-      return collect_languages(document);
+      return collectLanguages(document);
     }
 
-    get missing_languages(): Array<string> {
+    get missingLanguages(): Array<string> {
       // TODO: false negative for r vs R?
-      return [...this.detected_languages].filter(
-        language => !this.supported_languages.has(language.toLocaleLowerCase())
+      return [...this.detectedLanguages].filter(
+        language => !this.supportedLanguages.has(language.toLocaleLowerCase())
       );
     }
 
     get status(): IStatus {
-      let detected_documents: Map<string, VirtualDocument>;
+      let detectedDocuments: Map<string, VirtualDocument>;
 
       if (!this.adapter?.virtualDocument) {
-        detected_documents = new Map();
+        detectedDocuments = new Map();
       } else {
-        let main_document = this.adapter.virtualDocument;
-        const all_documents = this._connection_manager.documents;
+        let mainDocument = this.adapter.virtualDocument;
+        const allDocuments = this._connectionManager.documents;
         // detected documents that are open in the current virtual editor
-        const detected_documents_set = collectDocuments(main_document);
-        detected_documents = new Map(
-          [...all_documents].filter(([id, doc]) =>
-            detected_documents_set.has(doc)
-          )
+        const detectedDocumentsSet = collectDocuments(mainDocument);
+        detectedDocuments = new Map(
+          [...allDocuments].filter(([id, doc]) => detectedDocumentsSet.has(doc))
         );
       }
 
-      let connected_documents = new Set<VirtualDocument>();
-      let initialized_documents = new Set<VirtualDocument>();
-      let absent_documents = new Set<VirtualDocument>();
+      let connectedDocuments = new Set<VirtualDocument>();
+      let initializedDocuments = new Set<VirtualDocument>();
+      let absentDocuments = new Set<VirtualDocument>();
       // detected documents with LSP servers available
-      let documents_with_available_servers = new Set<VirtualDocument>();
+      let documentsWithAvailableServers = new Set<VirtualDocument>();
       // detected documents with LSP servers known
-      let documents_with_known_servers = new Set<VirtualDocument>();
+      let documentsWithKnownServers = new Set<VirtualDocument>();
 
-      detected_documents.forEach((document, uri) => {
-        let connection = this._connection_manager.connections.get(uri);
-        let server_ids =
-          this._connection_manager.languageServerManager.getMatchingServers({
+      detectedDocuments.forEach((document, uri) => {
+        let connection = this._connectionManager.connections.get(uri);
+        let serverIds =
+          this._connectionManager.languageServerManager.getMatchingServers({
             language: document.language
           });
 
-        if (server_ids.length !== 0) {
-          documents_with_known_servers.add(document);
+        if (serverIds.length !== 0) {
+          documentsWithKnownServers.add(document);
         }
         if (!connection) {
-          absent_documents.add(document);
+          absentDocuments.add(document);
           return;
         } else {
-          documents_with_available_servers.add(document);
+          documentsWithAvailableServers.add(document);
         }
 
         if (connection.isConnected) {
-          connected_documents.add(document);
+          connectedDocuments.add(document);
         }
         if (connection.isInitialized) {
-          initialized_documents.add(document);
+          initializedDocuments.add(document);
         }
       });
 
       // there may be more open connections than documents if a document was recently closed
       // and the grace period has not passed yet
-      let open_connections = new Array<ILSPConnection>();
-      this._connection_manager.connections.forEach((connection, path) => {
+      let openConnections = new Array<ILSPConnection>();
+      this._connectionManager.connections.forEach((connection, path) => {
         if (connection.isConnected) {
-          open_connections.push(connection);
+          openConnections.push(connection);
         }
       });
 
       let status: StatusCode;
-      if (this.language_server_manager.statusCode === 404) {
-        status = 'no_server_extension';
-      } else if (detected_documents.size === 0) {
+      if (this.languageServerManager.statusCode === 404) {
+        status = 'noServerExtension';
+      } else if (detectedDocuments.size === 0) {
         status = 'waiting';
-      } else if (initialized_documents.size === detected_documents.size) {
+      } else if (initializedDocuments.size === detectedDocuments.size) {
         status = 'initialized';
       } else if (
-        initialized_documents.size === documents_with_available_servers.size &&
-        detected_documents.size > documents_with_known_servers.size
+        initializedDocuments.size === documentsWithAvailableServers.size &&
+        detectedDocuments.size > documentsWithKnownServers.size
       ) {
-        status = 'initialized_but_some_missing';
+        status = 'initializedButSomeMissing';
       } else if (
-        connected_documents.size === documents_with_available_servers.size
+        connectedDocuments.size === documentsWithAvailableServers.size
       ) {
         status = 'initializing';
       } else {
@@ -743,15 +739,15 @@ export namespace LSPStatus {
       }
 
       return {
-        open_connections,
-        connected_documents,
-        initialized_documents,
-        detected_documents: new Set([...detected_documents.values()]),
+        openConnections,
+        connectedDocuments,
+        initializedDocuments,
+        detectedDocuments: new Set([...detectedDocuments.values()]),
         status
       };
     }
 
-    get status_icon(): LabIcon {
+    get statusIcon(): LabIcon {
       if (!this.adapter) {
         return stopIcon;
       }
@@ -760,14 +756,14 @@ export namespace LSPStatus {
       });
     }
 
-    get short_message(): string {
+    get shortMessage(): string {
       if (!this.adapter) {
         return this.trans.__('Not initialized');
       }
       return this._shortMessageByStatus[this.status.status];
     }
 
-    get long_message(): string {
+    get longMessage(): string {
       if (!this.adapter) {
         return this.trans.__('not initialized');
       }
@@ -779,14 +775,14 @@ export namespace LSPStatus {
         msg = this.trans._n(
           'Fully connected & initialized (%2 virtual document)',
           'Fully connected & initialized (%2 virtual document)',
-          status.detected_documents.size,
-          status.detected_documents.size
+          status.detectedDocuments.size,
+          status.detectedDocuments.size
         );
       } else if (status.status === 'initializing') {
         const uninitialized = new Set<VirtualDocument>(
-          status.detected_documents
+          status.detectedDocuments
         );
-        for (let initialized of status.initialized_documents.values()) {
+        for (let initialized of status.initializedDocuments.values()) {
           uninitialized.delete(initialized);
         }
         // servers for n documents did not respond to the initialization request
@@ -794,14 +790,14 @@ export namespace LSPStatus {
           'pluralized',
           'Fully connected, but %2/%3 virtual document stuck uninitialized: %4',
           'Fully connected, but %2/%3 virtual documents stuck uninitialized: %4',
-          status.detected_documents.size,
+          status.detectedDocuments.size,
           uninitialized.size,
-          status.detected_documents.size,
+          status.detectedDocuments.size,
           [...uninitialized].map(document => document.idPath).join(', ')
         );
       } else {
-        const unconnected = new Set<VirtualDocument>(status.detected_documents);
-        for (let connected of status.connected_documents.values()) {
+        const unconnected = new Set<VirtualDocument>(status.detectedDocuments);
+        for (let connected of status.connectedDocuments.values()) {
           unconnected.delete(connected);
         }
 
@@ -809,10 +805,10 @@ export namespace LSPStatus {
           'pluralized',
           '%2/%3 virtual document connected (%4 connections; waiting for: %5)',
           '%2/%3 virtual documents connected (%4 connections; waiting for: %5)',
-          status.detected_documents.size,
-          status.connected_documents.size,
-          status.detected_documents.size,
-          status.open_connections.length,
+          status.detectedDocuments.size,
+          status.connectedDocuments.size,
+          status.detectedDocuments.size,
+          status.openConnections.length,
           [...unconnected].map(document => document.idPath).join(', ')
         );
       }
@@ -820,37 +816,37 @@ export namespace LSPStatus {
     }
 
     get adapter(): WidgetLSPAdapter<IDocumentWidget> | null {
-      const adapter = [...this.connection_manager.adapters.values()].find(
+      const adapter = [...this.connectionManager.adapters.values()].find(
         adapter => adapter.widget == this._shell.currentWidget
       );
       return adapter ?? null;
     }
 
-    get connection_manager() {
-      return this._connection_manager;
+    get connectionManager() {
+      return this._connectionManager;
     }
 
     /**
-     * Note: it is ever only set once, as connection_manager is a singleton.
+     * Note: it is ever only set once, as connectionManager is a singleton.
      */
-    set connection_manager(connection_manager) {
-      if (this._connection_manager != null) {
-        this._connection_manager.connected.disconnect(this._onChange);
-        this._connection_manager.initialized.connect(this._onChange);
-        this._connection_manager.disconnected.disconnect(this._onChange);
-        this._connection_manager.closed.disconnect(this._onChange);
-        this._connection_manager.documentsChanged.disconnect(this._onChange);
+    set connectionManager(connectionManager) {
+      if (this._connectionManager != null) {
+        this._connectionManager.connected.disconnect(this._onChange);
+        this._connectionManager.initialized.connect(this._onChange);
+        this._connectionManager.disconnected.disconnect(this._onChange);
+        this._connectionManager.closed.disconnect(this._onChange);
+        this._connectionManager.documentsChanged.disconnect(this._onChange);
       }
 
-      if (connection_manager != null) {
-        connection_manager.connected.connect(this._onChange);
-        connection_manager.initialized.connect(this._onChange);
-        connection_manager.disconnected.connect(this._onChange);
-        connection_manager.closed.connect(this._onChange);
-        connection_manager.documentsChanged.connect(this._onChange);
+      if (connectionManager != null) {
+        connectionManager.connected.connect(this._onChange);
+        connectionManager.initialized.connect(this._onChange);
+        connectionManager.disconnected.connect(this._onChange);
+        connectionManager.closed.connect(this._onChange);
+        connectionManager.documentsChanged.connect(this._onChange);
       }
 
-      this._connection_manager = connection_manager;
+      this._connectionManager = connectionManager;
     }
 
     private _onChange = () => {

--- a/packages/jupyterlab-lsp/src/components/utils.spec.ts
+++ b/packages/jupyterlab-lsp/src/components/utils.spec.ts
@@ -6,7 +6,7 @@ import { VirtualDocument } from '../virtual/document';
 
 import { getBreadcrumbs } from './utils';
 
-function create_dummy_document(options: Partial<VirtualDocument.IOptions>) {
+function createDummyDocument(options: Partial<VirtualDocument.IOptions>) {
   return new VirtualDocument({
     language: 'python',
     overridesRegistry: {},
@@ -21,7 +21,7 @@ function create_dummy_document(options: Partial<VirtualDocument.IOptions>) {
 describe('getBreadcrumbs', () => {
   const trans = nullTranslator.load('jupyterlab_lsp');
   it('should collapse long paths', () => {
-    let document = create_dummy_document({
+    let document = createDummyDocument({
       path: 'dir1/dir2/Test.ipynb'
     });
     let breadcrumbs = getBreadcrumbs(
@@ -36,7 +36,7 @@ describe('getBreadcrumbs', () => {
   });
 
   it('should trim the extra filename suffix for files created out of notebooks', () => {
-    let document = create_dummy_document({
+    let document = createDummyDocument({
       path: 'Test.ipynb.py',
       fileExtension: 'py',
       hasLspSupportedFile: false
@@ -52,7 +52,7 @@ describe('getBreadcrumbs', () => {
   });
 
   it('should not trim the filename suffix for standalone files', () => {
-    let document = create_dummy_document({
+    let document = createDummyDocument({
       path: 'test.py',
       fileExtension: 'py',
       hasLspSupportedFile: true

--- a/packages/jupyterlab-lsp/src/components/utils.tsx
+++ b/packages/jupyterlab-lsp/src/components/utils.tsx
@@ -24,7 +24,7 @@ export function getBreadcrumbs(
       ) {
         path = path.slice(0, -document.fileExtension.length - 1);
       }
-      const full_path = path;
+      const fullPath = path;
       if (collapse) {
         let parts = path.split('/');
         if (parts.length > 2) {
@@ -32,7 +32,7 @@ export function getBreadcrumbs(
         }
       }
       return (
-        <span key={document.uri} title={full_path}>
+        <span key={document.uri} title={fullPath}>
           {path}
         </span>
       );
@@ -46,20 +46,20 @@ export function getBreadcrumbs(
     }
     try {
       if (adapter.hasMultipleEditors) {
-        let first_line = virtualLines.get(0)!;
-        let last_line = virtualLines.get(document.lastVirtualLine - 1)!;
+        let firstLine = virtualLines.get(0)!;
+        let lastLine = virtualLines.get(document.lastVirtualLine - 1)!;
 
-        let first_cell = adapter.getEditorIndex(first_line.editor);
-        let last_cell = adapter.getEditorIndex(last_line.editor);
+        let firstCell = adapter.getEditorIndex(firstLine.editor);
+        let lastCell = adapter.getEditorIndex(lastLine.editor);
 
-        let cell_locator =
-          first_cell === last_cell
-            ? trans!.__('cell %1', first_cell + 1)
-            : trans!.__('cells: %1-%2', first_cell + 1, last_cell + 1);
+        let cellLocator =
+          firstCell === lastCell
+            ? trans!.__('cell %1', firstCell + 1)
+            : trans!.__('cells: %1-%2', firstCell + 1, lastCell + 1);
 
         return (
           <span key={document.uri}>
-            {document.language} ({cell_locator})
+            {document.language} ({cellLocator})
           </span>
         );
       }
@@ -89,9 +89,9 @@ export function DocumentLocator(props: {
   if (adapter.hasMultipleEditors) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    let first_line = document.virtualLines.get(0);
-    if (first_line) {
-      target = first_line.editor;
+    let firstLine = document.virtualLines.get(0);
+    if (firstLine) {
+      target = firstLine.editor;
     } else {
       console.warn('Could not get first line of ', document);
     }

--- a/packages/jupyterlab-lsp/src/context.ts
+++ b/packages/jupyterlab-lsp/src/context.ts
@@ -107,8 +107,8 @@ export class ContextAssembler {
       return null;
     }
 
-    let ce_cursor = editor.getCursorPosition();
-    let cm_cursor = PositionConverter.ce_to_cm(ce_cursor) as IEditorPosition;
+    let ceCursor = editor.getCursorPosition();
+    let cmCursor = PositionConverter.ce_to_cm(ceCursor) as IEditorPosition;
 
     const virtualDocument = adapter.virtualDocument;
     if (!virtualDocument) {
@@ -117,7 +117,7 @@ export class ContextAssembler {
     }
     const rootPosition = virtualDocument.transformFromEditorToRoot(
       adapter.activeEditor!,
-      cm_cursor
+      cmCursor
     )!;
 
     if (rootPosition == null) {

--- a/packages/jupyterlab-lsp/src/converter.spec.ts
+++ b/packages/jupyterlab-lsp/src/converter.spec.ts
@@ -38,20 +38,20 @@ describe('Position conversion', () => {
 
   describe('#documentAtRootPosition()', () => {
     it('returns correct document', () => {
-      let ceEditor_for_cell_1 = {} as Document.IEditor;
-      let ceEditor_for_cell_2 = {} as Document.IEditor;
+      let ceEditorForCell1 = {} as Document.IEditor;
+      let ceEditorForCell2 = {} as Document.IEditor;
       const adapter = environment.adapter!;
       const mainDocument = environment.adapter.virtualDocument!;
 
       mainDocument.clear();
       mainDocument.appendCodeBlock({
         value: 'test line in Python 1\n%R test line in R 1',
-        ceEditor: ceEditor_for_cell_1,
+        ceEditor: ceEditorForCell1,
         type: 'code'
       });
       mainDocument.appendCodeBlock({
         value: 'test line in Python 2\n%R test line in R 2',
-        ceEditor: ceEditor_for_cell_2,
+        ceEditor: ceEditorForCell2,
         type: 'code'
       });
 

--- a/packages/jupyterlab-lsp/src/edits.spec.ts
+++ b/packages/jupyterlab-lsp/src/edits.spec.ts
@@ -8,7 +8,7 @@ import { EditApplicator } from './edits';
 import {
   codeCell,
   getCellsJSON,
-  python_notebook_metadata,
+  pythonNotebookMetadata,
   showAllCells,
   FileEditorTestEnvironment,
   NotebookTestEnvironment,
@@ -17,7 +17,7 @@ import {
 import { foreignCodeExtractors } from './transclusions/ipython/extractors';
 import { overrides } from './transclusions/ipython/overrides';
 
-const js_fib_code = `function fib(n) {
+const jsFibCode = `function fib(n) {
   return n<2?n:fib(n-1)+fib(n-2);
 }
 
@@ -25,7 +25,7 @@ fib(5);
 
 window.location /;`;
 
-const js_fib2_code = `function fib2(n) {
+const jsFib2Code = `function fib2(n) {
   return n<2?n:fib2(n-1)+fib2(n-2);
 }
 
@@ -33,7 +33,7 @@ fib2(5);
 
 window.location /;`;
 
-const js_partial_edits = [
+const jsPartialEdits = [
   {
     range: {
       start: {
@@ -130,8 +130,8 @@ describe('EditApplicator', () => {
         expect(environment.activeEditor.model.sharedModel.source).toBe(
           'changed bar'
         );
-        let raw_value = environment.activeEditor.editor.state.doc.toString();
-        expect(raw_value).toBe('changed bar');
+        let rawValue = environment.activeEditor.editor.state.doc.toString();
+        expect(rawValue).toBe('changed bar');
         expect(outcome.wasGranular).toBe(false);
         expect(outcome.modifiedCells).toBe(1);
         expect(outcome.appliedChanges).toBe(1);
@@ -146,8 +146,8 @@ describe('EditApplicator', () => {
             ['file:///' + environment.documentOptions.path]: []
           }
         });
-        let raw_value = environment.activeEditor.editor.state.doc.toString();
-        expect(raw_value).toBe('foo bar');
+        let rawValue = environment.activeEditor.editor.state.doc.toString();
+        expect(rawValue).toBe('foo bar');
         expect(environment.activeEditor.model.sharedModel.source).toBe(
           'foo bar'
         );
@@ -157,21 +157,21 @@ describe('EditApplicator', () => {
       });
 
       it('applies partial edits', async () => {
-        environment.activeEditor.model.sharedModel.setSource(js_fib_code);
+        environment.activeEditor.model.sharedModel.setSource(jsFibCode);
         await environment.adapter.updateDocuments();
 
         let result = await applicator.applyEdit({
           changes: {
-            ['file:///' + environment.documentOptions.path]: js_partial_edits
+            ['file:///' + environment.documentOptions.path]: jsPartialEdits
           }
         });
-        let raw_value = environment.activeEditor.editor.state.doc.toString();
-        expect(raw_value).toBe(js_fib2_code);
+        let rawValue = environment.activeEditor.editor.state.doc.toString();
+        expect(rawValue).toBe(jsFib2Code);
         expect(environment.activeEditor.model.sharedModel.source).toBe(
-          js_fib2_code
+          jsFib2Code
         );
 
-        expect(result.appliedChanges).toBe(js_partial_edits.length);
+        expect(result.appliedChanges).toBe(jsPartialEdits.length);
         expect(result.wasGranular).toBe(true);
         expect(result.modifiedCells).toBe(1);
       });
@@ -216,28 +216,28 @@ describe('EditApplicator', () => {
       }
 
       it('applies edit across cells', async () => {
-        let test_notebook = {
+        let testNotebook = {
           cells: [
             codeCell(['def a_function():', '    pass']),
             codeCell(['x = a_function()'])
           ],
-          metadata: python_notebook_metadata
+          metadata: pythonNotebookMetadata
         } as nbformat.INotebookContent;
 
         let notebook = environment.notebook;
 
         notebook.model = new NotebookModel();
-        notebook.model.fromJSON(test_notebook);
+        notebook.model.fromJSON(testNotebook);
         showAllCells(notebook);
 
         await synchronizeContent();
         let mainDocument = environment.adapter.virtualDocument!;
 
-        let old_virtual_source =
+        let oldVirtualSource =
           'def a_function():\n    pass\n\n\nx = a_function()\n';
-        let new_virtual_source =
+        let newVirtualSource =
           'def a_function_2():\n    pass\n\n\nx = a_function_2()\n';
-        expect(mainDocument.value).toBe(old_virtual_source);
+        expect(mainDocument.value).toBe(oldVirtualSource);
 
         let outcome = await applicator.applyEdit({
           changes: {
@@ -247,7 +247,7 @@ describe('EditApplicator', () => {
                   start: { line: 0, character: 0 },
                   end: { line: 5, character: 0 }
                 },
-                newText: new_virtual_source
+                newText: newVirtualSource
               } as lsProtocol.TextEdit
             ]
           }
@@ -256,7 +256,7 @@ describe('EditApplicator', () => {
         await synchronizeContent();
 
         let value = mainDocument.value;
-        expect(value).toBe(new_virtual_source);
+        expect(value).toBe(newVirtualSource);
 
         let codeCells = getCellsJSON(notebook);
 
@@ -272,18 +272,18 @@ describe('EditApplicator', () => {
       });
 
       it('handles IPython magics', async () => {
-        let test_notebook = {
+        let testNotebook = {
           cells: [
             codeCell(['x = %ls', 'print(x)']),
             codeCell(['%%python', 'y = x', 'print(x)'])
           ],
-          metadata: python_notebook_metadata
+          metadata: pythonNotebookMetadata
         } as nbformat.INotebookContent;
 
         let notebook = environment.notebook;
 
         notebook.model = new NotebookModel();
-        notebook.model.fromJSON(test_notebook);
+        notebook.model.fromJSON(testNotebook);
         showAllCells(notebook);
 
         await (environment.adapter as MockNotebookAdapter).foreingDocumentOpened
@@ -291,7 +291,7 @@ describe('EditApplicator', () => {
 
         let mainDocument = environment.adapter.virtualDocument!;
 
-        let old_virtual_source = `x = get_ipython().run_line_magic("ls", "")
+        let oldVirtualSource = `x = get_ipython().run_line_magic("ls", "")
 print(x)
 
 
@@ -299,7 +299,7 @@ get_ipython().run_cell_magic("python", "", """y = x
 print(x)""")
 `;
 
-        let new_virtual_source = `z = get_ipython().run_line_magic("ls", "")
+        let newVirtualSource = `z = get_ipython().run_line_magic("ls", "")
 print(z)
 
 
@@ -308,7 +308,7 @@ print(x)""")
 `;
 
         await synchronizeContent();
-        expect(mainDocument.value).toBe(old_virtual_source);
+        expect(mainDocument.value).toBe(oldVirtualSource);
 
         await applicator.applyEdit({
           changes: {
@@ -318,7 +318,7 @@ print(x)""")
                   start: { line: 0, character: 0 },
                   end: { line: 6, character: 10 }
                 },
-                newText: new_virtual_source
+                newText: newVirtualSource
               } as lsProtocol.TextEdit
             ]
           }
@@ -327,7 +327,7 @@ print(x)""")
           .promise;
 
         await synchronizeContent();
-        expect(mainDocument.value).toBe(new_virtual_source);
+        expect(mainDocument.value).toBe(newVirtualSource);
 
         let codeCells = getCellsJSON(notebook);
 

--- a/packages/jupyterlab-lsp/src/errors.tsx
+++ b/packages/jupyterlab-lsp/src/errors.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function external_link(url: string, label: string) {
+function externalLink(url: string, label: string) {
   return (
     <a
       href={url}
@@ -13,9 +13,9 @@ function external_link(url: string, label: string) {
   );
 }
 
-const migration_guide_url =
+const migrationGuideUrl =
   'https://jupyter-server.readthedocs.io/en/latest/operators/migrate-from-nbserver.html';
-const jupyter_hub_migration_url =
+const jupyterHubMigrationUrl =
   'https://github.com/jupyterhub/jupyterhub/pull/3329/files';
 
 export const SERVER_EXTENSION_404 = (
@@ -34,11 +34,11 @@ export const SERVER_EXTENSION_404 = (
       <li>
         Alternatively, you may be using an older <code>notebook</code> server
         instead of the new <code>jupyter_server</code>; please refer to the{' '}
-        {external_link(migration_guide_url, 'migration guide')} or if you are a
+        {externalLink(migrationGuideUrl, 'migration guide')} or if you are a
         JupyterHub user please ensure that you start the JupyterLab using{' '}
         <code>jupyter_server</code> and not the old <code>notebook</code>, as
         documented in{' '}
-        {external_link(jupyter_hub_migration_url, 'this pull request')}.
+        {externalLink(jupyterHubMigrationUrl, 'this pull request')}.
       </li>
       <li>
         There may be schema errors or language server errors preventing the

--- a/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
+++ b/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
@@ -38,7 +38,7 @@ describe('getIndexOfCaptureGroup', () => {
 });
 
 describe('RegExpForeignCodeExtractor', () => {
-  let r_cell_extractor = new RegExpForeignCodeExtractor({
+  let rCellEextractor = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '^%%R( .*?)?\n([^]*)',
     foreignCaptureGroups: [2],
@@ -47,7 +47,7 @@ describe('RegExpForeignCodeExtractor', () => {
     fileExtension: 'R'
   });
 
-  let r_line_extractor = new RegExpForeignCodeExtractor({
+  let rLineExtractor = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '(^|\n)%R (.*)\n?',
     foreignCaptureGroups: [2],
@@ -56,7 +56,7 @@ describe('RegExpForeignCodeExtractor', () => {
     fileExtension: 'R'
   });
 
-  let python_cell_extractor = new RegExpForeignCodeExtractor({
+  let pythonCellExtractor = new RegExpForeignCodeExtractor({
     language: 'python',
     pattern: '^%%(python|python2|python3|pypy)( .*?)?\\n([^]*)',
     foreignCaptureGroups: [3],
@@ -67,13 +67,13 @@ describe('RegExpForeignCodeExtractor', () => {
 
   describe('#hasForeignCode()', () => {
     it('detects cell magics', () => {
-      let result = r_cell_extractor.hasForeignCode(R_CELL_MAGIC_EXISTS);
+      let result = rCellEextractor.hasForeignCode(R_CELL_MAGIC_EXISTS);
       expect(result).toBe(true);
 
-      result = r_cell_extractor.hasForeignCode(R_LINE_MAGICS);
+      result = rCellEextractor.hasForeignCode(R_LINE_MAGICS);
       expect(result).toBe(false);
 
-      result = r_cell_extractor.hasForeignCode(NO_CELL_MAGIC);
+      result = rCellEextractor.hasForeignCode(NO_CELL_MAGIC);
       expect(result).toBe(false);
     });
 
@@ -81,25 +81,25 @@ describe('RegExpForeignCodeExtractor', () => {
       // stateful implementation of regular expressions in JS can easily lead to
       // an error manifesting it two consecutive checks giving different results,
       // as the last index was moved in between:
-      let result = r_cell_extractor.hasForeignCode(R_CELL_MAGIC_EXISTS);
+      let result = rCellEextractor.hasForeignCode(R_CELL_MAGIC_EXISTS);
       expect(result).toBe(true);
 
-      result = r_cell_extractor.hasForeignCode(R_CELL_MAGIC_EXISTS);
+      result = rCellEextractor.hasForeignCode(R_CELL_MAGIC_EXISTS);
       expect(result).toBe(true);
     });
 
     it('detects line magics', () => {
-      let result = r_line_extractor.hasForeignCode(R_LINE_MAGICS);
+      let result = rLineExtractor.hasForeignCode(R_LINE_MAGICS);
       expect(result).toBe(true);
 
-      result = r_line_extractor.hasForeignCode(R_CELL_MAGIC_EXISTS);
+      result = rLineExtractor.hasForeignCode(R_CELL_MAGIC_EXISTS);
       expect(result).toBe(false);
     });
   });
 
   describe('#extractForeignCode()', () => {
     it('should correctly return the range', () => {
-      let results = python_cell_extractor.extractForeignCode(
+      let results = pythonCellExtractor.extractForeignCode(
         PYTHON_CELL_MAGIC_WITH_H
       );
       expect(results.length).toBe(1);
@@ -119,7 +119,7 @@ describe('RegExpForeignCodeExtractor', () => {
     it('should work with non-line magic and non-cell magic code snippets as well', () => {
       // Note: in the real application, one should NOT use regular expressions for HTML extraction
 
-      let html_extractor = new RegExpForeignCodeExtractor({
+      let htmlExtractor = new RegExpForeignCodeExtractor({
         language: 'HTML',
         pattern: '(<(.*?)( .*?)?>([^]*?)</\\2>)',
         foreignCaptureGroups: [1],
@@ -128,7 +128,7 @@ describe('RegExpForeignCodeExtractor', () => {
         fileExtension: 'html'
       });
 
-      let results = html_extractor.extractForeignCode(HTML_IN_PYTHON);
+      let results = htmlExtractor.extractForeignCode(HTML_IN_PYTHON);
       expect(results.length).toBe(2);
       let result = results[0];
       // TODO: is tolerating the new line added here ok?
@@ -140,12 +140,12 @@ describe('RegExpForeignCodeExtractor', () => {
       expect(result.range!.start.column).toBe(7);
       expect(result.range!.end.line).toBe(3);
       expect(result.range!.end.column).toBe(4);
-      let last_bit = results[1];
-      expect(last_bit.hostCode).toBe('""";\nprint(x)');
+      let lastBit = results[1];
+      expect(lastBit.hostCode).toBe('""";\nprint(x)');
     });
 
     it('should extract cell magics and keep in host', () => {
-      let results = r_cell_extractor.extractForeignCode(R_CELL_MAGIC_EXISTS);
+      let results = rCellEextractor.extractForeignCode(R_CELL_MAGIC_EXISTS);
       expect(results.length).toBe(1);
       let result = results[0];
 
@@ -174,7 +174,7 @@ describe('RegExpForeignCodeExtractor', () => {
     });
 
     it('should extract multiple line magics deleting them from host', () => {
-      let r_line_extractor = new RegExpForeignCodeExtractor({
+      let rLineExtractor = new RegExpForeignCodeExtractor({
         language: 'R',
         pattern: '(^|\n)%R (.*)\n?',
         foreignCaptureGroups: [2],
@@ -182,55 +182,53 @@ describe('RegExpForeignCodeExtractor', () => {
         isStandalone: false,
         fileExtension: 'R'
       });
-      let results = r_line_extractor.extractForeignCode(R_LINE_MAGICS);
+      let results = rLineExtractor.extractForeignCode(R_LINE_MAGICS);
 
       // 2 line magics to be extracted + the unprocessed host code
       expect(results.length).toBe(3);
 
-      let first_magic = results[0];
+      let firstMagic = results[0];
 
-      expect(first_magic.foreignCode).toBe('df = data.frame()');
-      expect(first_magic.hostCode).toBe('');
+      expect(firstMagic.foreignCode).toBe('df = data.frame()');
+      expect(firstMagic.hostCode).toBe('');
 
-      let second_magic = results[1];
+      let secondMagic = results[1];
 
-      expect(second_magic.foreignCode).toBe('ggplot(df)');
-      expect(second_magic.hostCode).toBe('print("df created")\n');
+      expect(secondMagic.foreignCode).toBe('ggplot(df)');
+      expect(secondMagic.hostCode).toBe('print("df created")\n');
 
-      let final_bit = results[2];
+      let finalBit = results[2];
 
-      expect(final_bit.foreignCode).toBe(null);
-      expect(final_bit.hostCode).toBe('print("plotted")\n');
+      expect(finalBit.foreignCode).toBe(null);
+      expect(finalBit.hostCode).toBe('print("plotted")\n');
     });
 
     it('should extract multiple line magics preserving them in host', () => {
-      let results = r_line_extractor.extractForeignCode(R_LINE_MAGICS);
+      let results = rLineExtractor.extractForeignCode(R_LINE_MAGICS);
 
       // 2 line magics to be extracted + the unprocessed host code
       expect(results.length).toBe(3);
 
-      let first_magic = results[0];
+      let firstMagic = results[0];
 
-      expect(first_magic.foreignCode).toBe('df = data.frame()');
-      expect(first_magic.hostCode).toBe('%R df = data.frame()\n');
-      expect(first_magic.range!.end.line).toBe(0);
-      expect(first_magic.range!.end.column).toBe(20);
+      expect(firstMagic.foreignCode).toBe('df = data.frame()');
+      expect(firstMagic.hostCode).toBe('%R df = data.frame()\n');
+      expect(firstMagic.range!.end.line).toBe(0);
+      expect(firstMagic.range!.end.column).toBe(20);
 
-      let second_magic = results[1];
+      let secondMagic = results[1];
 
-      expect(second_magic.foreignCode).toBe('ggplot(df)');
-      expect(second_magic.hostCode).toBe(
-        'print("df created")\n%R ggplot(df)\n'
-      );
+      expect(secondMagic.foreignCode).toBe('ggplot(df)');
+      expect(secondMagic.hostCode).toBe('print("df created")\n%R ggplot(df)\n');
 
-      let final_bit = results[2];
+      let finalBit = results[2];
 
-      expect(final_bit.foreignCode).toBe(null);
-      expect(final_bit.hostCode).toBe('print("plotted")\n');
+      expect(finalBit.foreignCode).toBe(null);
+      expect(finalBit.hostCode).toBe('print("plotted")\n');
     });
 
     it('should extract single line magic which does not end with a blank line', () => {
-      let results = r_line_extractor.extractForeignCode('%R test');
+      let results = rLineExtractor.extractForeignCode('%R test');
 
       expect(results.length).toBe(1);
       let result = results[0];
@@ -238,7 +236,7 @@ describe('RegExpForeignCodeExtractor', () => {
     });
 
     it('should not extract magic-like text from the middle of the cell', () => {
-      let results = r_cell_extractor.extractForeignCode(NO_CELL_MAGIC);
+      let results = rCellEextractor.extractForeignCode(NO_CELL_MAGIC);
 
       expect(results.length).toBe(1);
       let result = results[0];

--- a/packages/jupyterlab-lsp/src/extractors/testutils.ts
+++ b/packages/jupyterlab-lsp/src/extractors/testutils.ts
@@ -35,20 +35,20 @@ interface IDocumentWithRange {
 }
 
 export function getTheOnlyPair(
-  foreignDocument_map: Map<CodeEditor.IRange, Document.IVirtualDocumentBlock>
+  foreignDocumentMap: Map<CodeEditor.IRange, Document.IVirtualDocumentBlock>
 ): IDocumentWithRange {
-  expect(foreignDocument_map.size).toBe(1);
+  expect(foreignDocumentMap.size).toBe(1);
 
-  let range = foreignDocument_map.keys().next().value;
-  let { virtualDocument } = foreignDocument_map.get(range)!;
+  let range = foreignDocumentMap.keys().next().value;
+  let { virtualDocument } = foreignDocumentMap.get(range)!;
 
   return { range, virtualDocument };
 }
 
 export function getTheOnlyVirtual(
-  foreignDocument_map: Map<CodeEditor.IRange, Document.IVirtualDocumentBlock>
+  foreignDocumentMap: Map<CodeEditor.IRange, Document.IVirtualDocumentBlock>
 ) {
-  let { virtualDocument } = getTheOnlyPair(foreignDocument_map);
+  let { virtualDocument } = getTheOnlyPair(foreignDocumentMap);
   return virtualDocument;
 }
 

--- a/packages/jupyterlab-lsp/src/features/completion/index.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/index.ts
@@ -75,10 +75,10 @@ export class CompletionFeature extends Feature {
 
     if (!settings.composite.disable) {
       document.body.dataset.lspCompleterLayout = settings.composite.layout;
-      completionThemeManager.set_theme(settings.composite.theme);
-      completionThemeManager.set_icons_overrides(settings.composite.typesMap);
+      completionThemeManager.setTheme(settings.composite.theme);
+      completionThemeManager.setIconsOverrides(settings.composite.typesMap);
     } else {
-      completionThemeManager.set_theme(null);
+      completionThemeManager.setTheme(null);
       delete document.body.dataset.lspCompleterLayout;
     }
   }

--- a/packages/jupyterlab-lsp/src/features/completion/item.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/item.ts
@@ -32,7 +32,7 @@ namespace CompletionItem {
 export class CompletionItem implements IExtendedCompletionItem {
   private _detail: string | undefined;
   private _documentation: string | undefined;
-  private _is_documentation_markdown: boolean;
+  private _isDocumentationMarkdown: boolean;
   private _resolved: boolean;
   /**
    * Self-reference to make sure that the instance for will remain accessible
@@ -45,7 +45,7 @@ export class CompletionItem implements IExtendedCompletionItem {
   private _currentInsertText: string;
 
   get isDocumentationMarkdown(): boolean {
-    return this._is_documentation_markdown;
+    return this._isDocumentationMarkdown;
   }
 
   /**
@@ -78,10 +78,10 @@ export class CompletionItem implements IExtendedCompletionItem {
   ) {
     if (lsProtocol.MarkupContent.is(documentation)) {
       this._documentation = documentation.value;
-      this._is_documentation_markdown = documentation.kind === 'markdown';
+      this._isDocumentationMarkdown = documentation.kind === 'markdown';
     } else {
       this._documentation = documentation;
-      this._is_documentation_markdown = false;
+      this._isDocumentationMarkdown = false;
     }
   }
 

--- a/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
@@ -6,7 +6,7 @@ import { LSPCompleterModel } from './model';
 describe('LSPCompleterModel', () => {
   let model: LSPCompleterModel;
 
-  function create_dummy_item(
+  function createDummyItem(
     match: lsProtocol.CompletionItem,
     type: string = 'dummy'
   ) {
@@ -19,24 +19,24 @@ describe('LSPCompleterModel', () => {
     });
   }
 
-  const jupyter_icon_completion = create_dummy_item({
+  const jupyterIconCompletion = createDummyItem({
     label: '<i class="jp-icon-jupyter"></i> Jupyter',
     filterText: 'i font icon jupyter Jupyter',
     documentation: 'A Jupyter icon implemented with <i> tag'
   });
-  const test_a_completion = create_dummy_item({
+  const testCompletionA = createDummyItem({
     label: 'test',
     sortText: 'a'
   });
-  const test_b_completion = create_dummy_item({
+  const testCompletionB = createDummyItem({
     label: 'test',
     sortText: 'b'
   });
-  const test_c_completion = create_dummy_item({
+  const testCompletionC = createDummyItem({
     label: 'test',
     sortText: 'c'
   });
-  const test_test_completion = create_dummy_item({
+  const testCompletionTest = createDummyItem({
     label: 'test_test',
     sortText: 'test_test'
   });
@@ -49,7 +49,7 @@ describe('LSPCompleterModel', () => {
   });
 
   it('returns escaped when no query', () => {
-    model.setCompletionItems([jupyter_icon_completion]);
+    model.setCompletionItems([jupyterIconCompletion]);
     model.query = '';
 
     let markedItems = model.completionItems();
@@ -59,7 +59,7 @@ describe('LSPCompleterModel', () => {
   });
 
   it('marks html correctly', () => {
-    model.setCompletionItems([jupyter_icon_completion]);
+    model.setCompletionItems([jupyterIconCompletion]);
     model.query = 'Jup';
 
     let markedItems = model.completionItems();
@@ -70,9 +70,9 @@ describe('LSPCompleterModel', () => {
 
   it('ties are solved with sortText', () => {
     model.setCompletionItems([
-      test_a_completion,
-      test_c_completion,
-      test_b_completion
+      testCompletionA,
+      testCompletionC,
+      testCompletionB
     ]);
     model.query = 'test';
     let sortedItems = model.completionItems();
@@ -84,7 +84,7 @@ describe('LSPCompleterModel', () => {
       includePerfectMatches: false
     });
 
-    model.setCompletionItems([test_a_completion, test_test_completion]);
+    model.setCompletionItems([testCompletionA, testCompletionTest]);
     model.query = 'test';
     let items = model.completionItems();
     // should not include the perfect match 'test'
@@ -94,7 +94,7 @@ describe('LSPCompleterModel', () => {
 
   it('case-sensitivity can be changed', () => {
     model = new LSPCompleterModel();
-    model.setCompletionItems([test_a_completion]);
+    model.setCompletionItems([testCompletionA]);
     model.query = 'Test';
 
     model.settings.caseSensitive = true;
@@ -107,7 +107,7 @@ describe('LSPCompleterModel', () => {
   });
 
   it('filters use filterText', () => {
-    model.setCompletionItems([jupyter_icon_completion]);
+    model.setCompletionItems([jupyterIconCompletion]);
     // font is in filterText but not in label
     model.query = 'font';
 
@@ -121,7 +121,7 @@ describe('LSPCompleterModel', () => {
   });
 
   it('marks appropriate part of label when filterText matches', () => {
-    model.setCompletionItems([jupyter_icon_completion]);
+    model.setCompletionItems([jupyterIconCompletion]);
     // font is in filterText but not in label
     model.query = 'font';
 

--- a/packages/jupyterlab-lsp/src/features/completion/overrides.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/overrides.ts
@@ -47,9 +47,7 @@ export class EnhancedContextCompleterProvider extends ContextCompleterProvider {
   }
 
   protected iconFor(type: string): LabIcon | undefined {
-    const icon = this.options.iconsThemeManager.get_icon(
-      type
-    ) as LabIcon | null;
+    const icon = this.options.iconsThemeManager.getIcon(type) as LabIcon | null;
     return icon ? icon : undefined;
   }
 }
@@ -78,9 +76,7 @@ export class EnhancedKernelCompleterProvider extends KernelCompleterProvider {
   }
 
   protected iconFor(type: string): LabIcon | undefined {
-    const icon = this.options.iconsThemeManager.get_icon(
-      type
-    ) as LabIcon | null;
+    const icon = this.options.iconsThemeManager.getIcon(type) as LabIcon | null;
     return icon ? icon : undefined;
   }
 }

--- a/packages/jupyterlab-lsp/src/features/completion/provider.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/provider.ts
@@ -284,7 +284,7 @@ export class CompletionProvider implements ICompletionProvider<CompletionItem> {
           match,
           connection,
           type: kind,
-          icon: this.options.iconsThemeManager.get_icon(kind) as LabIcon | null,
+          icon: this.options.iconsThemeManager.getIcon(kind) as LabIcon | null,
           source: this.label
         });
       },
@@ -318,7 +318,7 @@ export function transformLSPCompletions<T>(
   console: ILSPLogConsole
 ) {
   let prefix = token.value.slice(0, positionInToken + 1);
-  let all_non_prefixed = true;
+  let allNonPrefixed = true;
   let items: T[] = [];
   lspCompletionItems.forEach(match => {
     let kind = match.kind ? CompletionItemKind[match.kind] : '';
@@ -328,7 +328,7 @@ export function transformLSPCompletions<T>(
 
     // declare prefix presence if needed and update it
     if (text.toLowerCase().startsWith(prefix.toLowerCase())) {
-      all_non_prefixed = false;
+      allNonPrefixed = false;
       if (prefix !== token.value) {
         if (text.toLowerCase().startsWith(token.value.toLowerCase())) {
           // given a completion insert text "display_table" and two test cases:
@@ -357,7 +357,7 @@ export function transformLSPCompletions<T>(
           pathPrefix = pathPrefix.substr(1);
         }
         match.label = pathPrefix + match.label;
-        all_non_prefixed = false;
+        allNonPrefixed = false;
       }
     }
 
@@ -368,12 +368,12 @@ export function transformLSPCompletions<T>(
   console.debug('Transformed');
   // required to make the repetitive trigger characters like :: or ::: work for R with R languageserver,
   // see https://github.com/jupyter-lsp/jupyterlab-lsp/issues/436
-  let prefix_offset = token.value.length;
+  let prefixOffset = token.value.length;
   // completion of dictionaries for Python with jedi-language-server was
   // causing an issue for dic['<tab>'] case; to avoid this let's make
   // sure that prefix.length >= prefix.offset
-  if (all_non_prefixed && prefix_offset > prefix.length) {
-    prefix_offset = prefix.length;
+  if (allNonPrefixed && prefixOffset > prefix.length) {
+    prefixOffset = prefix.length;
   }
 
   let response = {
@@ -386,7 +386,7 @@ export function transformLSPCompletions<T>(
     // a different workaround would be to prepend the token.value prefix:
     // text = token.value + text;
     // but it did not work for "from statistics <tab>" and lead to "from statisticsimport" (no space)
-    start: token.offset + (all_non_prefixed ? prefix_offset : 0),
+    start: token.offset + (allNonPrefixed ? prefixOffset : 0),
     end: token.offset + prefix.length,
     items: items,
     source: 'LSP'

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -126,23 +126,23 @@ export class LSPCompletionRenderer
     const li = super.createCompletionItemNode(item, orderedTypes);
 
     // make sure that an instance reference, and not an object copy is being used;
-    const lsp_item = item.self;
+    const lspItem = item.self;
 
     // only monitor nodes that have item.self as others are not our completion items
-    if (lsp_item) {
-      lsp_item.element = li;
-      this.elementToItem.set(li, lsp_item);
+    if (lspItem) {
+      lspItem.element = li;
+      this.elementToItem.set(li, lspItem);
       this.activityObserver.observe(li, {
         attributes: true,
         attributeFilter: ['class']
       });
       this.visibilityObserver.observe(li);
       // TODO: build custom li from ground up
-      this.updateExtraInfo(lsp_item, li);
-      this._elideMark(lsp_item, li);
+      this.updateExtraInfo(lspItem, li);
+      this._elideMark(lspItem, li);
     } else {
       this.updateExtraInfo(item, li);
-      this._elideMark(lsp_item, li);
+      this._elideMark(lspItem, li);
     }
 
     return li;

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
@@ -301,18 +301,18 @@ describe('Diagnostics', () => {
       );
       await framePromise();
 
-      let cm_editors = env.adapter.editors.map(
+      let cmEditors = env.adapter.editors.map(
         editor => (editor.ceEditor.getEditor()! as CodeMirrorEditor).editor
       );
-      const marks_cell_1 = getDiagnostics(cm_editors[0].state);
+      const marksCell1 = getDiagnostics(cmEditors[0].state);
       // test from mypy, test from pyflakes, whitespace around operator from pycodestyle
-      expect(marks_cell_1.length).toBe(3);
+      expect(marksCell1.length).toBe(3);
 
-      const marks_cell_2 = getDiagnostics(cm_editors[1].state);
-      expect(marks_cell_2.length).toBe(2);
+      const marksCell2 = getDiagnostics(cmEditors[1].state);
+      expect(marksCell2.length).toBe(2);
 
-      expect(marks_cell_2[1].message).toContain('W391');
-      expect(marks_cell_2[0].message).toContain('W293');
+      expect(marksCell2[1].message).toContain('W391');
+      expect(marksCell2[0].message).toContain('W293');
 
       expect(feature.getDiagnosticsDB(env.adapter).size).toBe(1);
       expect(feature.getDiagnosticsDB(env.adapter).get(document)!.length).toBe(
@@ -358,15 +358,15 @@ describe('Diagnostics', () => {
       // test guards against wrongly propagated responses:
       await feature.handleDiagnostic(response, foreignDocument, env.adapter);
 
-      let cm_editors = env.adapter.editors.map(
+      let cmEditors = env.adapter.editors.map(
         editor => editor.ceEditor.getEditor()! as CodeMirrorEditor
       );
 
-      let marks_cell_1 = getDiagnostics(cm_editors[0].state);
-      let marks_cell_2 = getDiagnostics(cm_editors[1].state);
+      let marksCell1 = getDiagnostics(cmEditors[0].state);
+      let marksCell2 = getDiagnostics(cmEditors[1].state);
 
-      expect(marks_cell_1.length).toBe(0);
-      expect(marks_cell_2.length).toBe(0);
+      expect(marksCell1.length).toBe(0);
+      expect(marksCell2.length).toBe(0);
 
       // correct propagation
       await feature.handleDiagnostic(
@@ -375,16 +375,16 @@ describe('Diagnostics', () => {
         env.adapter
       );
 
-      marks_cell_1 = getDiagnostics(cm_editors[0].state);
-      marks_cell_2 = getDiagnostics(cm_editors[1].state);
+      marksCell1 = getDiagnostics(cmEditors[0].state);
+      marksCell2 = getDiagnostics(cmEditors[1].state);
 
-      expect(marks_cell_1.length).toBe(0);
-      expect(marks_cell_2.length).toBe(1);
+      expect(marksCell1.length).toBe(0);
+      expect(marksCell2.length).toBe(1);
 
-      let mark = marks_cell_2[0];
+      let mark = marksCell2[0];
 
-      const from = cm_editors[1].getPositionAt(mark.from);
-      const to = cm_editors[1].getPositionAt(mark.to);
+      const from = cmEditors[1].getPositionAt(mark.from);
+      const to = cmEditors[1].getPositionAt(mark.to);
 
       // second line (0th and 1st virtual lines) + 1 line for '%%python\n' => line: 2
       expect(
@@ -414,7 +414,7 @@ describe('Diagnostics', () => {
         env.adapter
       );
 
-      expect(marks_cell_1.length).toBe(0);
+      expect(marksCell1.length).toBe(0);
     });
   });
 });

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -41,7 +41,7 @@ class DiagnosticsPanel {
   private _content: DiagnosticsListing | null = null;
   private _widget: MainAreaWidget<DiagnosticsListing> | null = null;
   feature: DiagnosticsFeature;
-  is_registered = false;
+  isRegistered = false;
   trans: TranslationBundle;
 
   constructor(trans: TranslationBundle) {
@@ -87,7 +87,7 @@ class DiagnosticsPanel {
   register(app: JupyterFrontEnd) {
     const widget = this.widget;
 
-    let get_column = (id: string) => {
+    let getColumn = (id: string) => {
       // TODO: a hashmap in the panel itself?
       for (let column of widget.content.columns) {
         if (column.id === id) {
@@ -98,59 +98,59 @@ class DiagnosticsPanel {
     };
 
     /** Columns Menu **/
-    let columns_menu = new Menu({ commands: app.commands });
-    columns_menu.title.label = this.trans.__('Panel columns');
+    let columnsMenu = new Menu({ commands: app.commands });
+    columnsMenu.title.label = this.trans.__('Panel columns');
 
     app.commands.addCommand(CMD_COLUMN_VISIBILITY, {
       execute: args => {
-        let column = get_column(args['id'] as string)!;
-        column.is_visible = !column.is_visible;
+        let column = getColumn(args['id'] as string)!;
+        column.isVisible = !column.isVisible;
         widget.update();
       },
       label: args => this.trans.__(args['id'] as string),
       isToggled: args => {
-        let column = get_column(args['id'] as string);
-        return column ? column.is_visible : false;
+        let column = getColumn(args['id'] as string);
+        return column ? column.isVisible : false;
       }
     });
 
     for (let column of widget.content.columns) {
-      columns_menu.addItem({
+      columnsMenu.addItem({
         command: CMD_COLUMN_VISIBILITY,
         args: { id: column.id }
       });
     }
     app.contextMenu.addItem({
       selector: '.' + DIAGNOSTICS_LISTING_CLASS + ' th',
-      submenu: columns_menu,
+      submenu: columnsMenu,
       type: 'submenu'
     });
 
     /** Diagnostics Menu **/
-    let ignore_diagnostics_menu = new Menu({ commands: app.commands });
-    ignore_diagnostics_menu.title.label = this.trans.__(
+    let ignoreDiagnosticsMenu = new Menu({ commands: app.commands });
+    ignoreDiagnosticsMenu.title.label = this.trans.__(
       'Ignore diagnostics like this'
     );
 
-    let get_row = (): IDiagnosticsRow | undefined => {
+    let getRow = (): IDiagnosticsRow | undefined => {
       let tr = app.contextMenuHitTest(
         node => node.tagName.toLowerCase() == 'tr'
       );
       if (!tr) {
         return;
       }
-      return this.widget.content.get_diagnostic(tr.dataset.key!);
+      return this.widget.content.getDiagnostic(tr.dataset.key!);
     };
 
-    ignore_diagnostics_menu.addItem({
+    ignoreDiagnosticsMenu.addItem({
       command: CMD_IGNORE_DIAGNOSTIC_CODE
     });
-    ignore_diagnostics_menu.addItem({
+    ignoreDiagnosticsMenu.addItem({
       command: CMD_IGNORE_DIAGNOSTIC_MSG
     });
     app.commands.addCommand(CMD_IGNORE_DIAGNOSTIC_CODE, {
       execute: () => {
-        const row = get_row();
+        const row = getRow();
         if (!row) {
           console.warn(
             'LPS: diagnostics row not found for ignore code execute()'
@@ -166,7 +166,7 @@ class DiagnosticsPanel {
         this.feature.refreshDiagnostics();
       },
       isVisible: () => {
-        const row = get_row();
+        const row = getRow();
         if (!row) {
           return false;
         }
@@ -174,7 +174,7 @@ class DiagnosticsPanel {
         return !!diagnostic.code;
       },
       label: () => {
-        const row = get_row();
+        const row = getRow();
         if (!row) {
           return '';
         }
@@ -187,7 +187,7 @@ class DiagnosticsPanel {
     });
     app.commands.addCommand(CMD_IGNORE_DIAGNOSTIC_MSG, {
       execute: () => {
-        const row = get_row();
+        const row = getRow();
         if (!row) {
           console.warn(
             'LPS: diagnostics row not found for ignore message execute()'
@@ -204,7 +204,7 @@ class DiagnosticsPanel {
         this.feature.refreshDiagnostics();
       },
       isVisible: () => {
-        const row = get_row();
+        const row = getRow();
         if (!row) {
           return false;
         }
@@ -212,7 +212,7 @@ class DiagnosticsPanel {
         return !!diagnostic.message;
       },
       label: () => {
-        const row = get_row();
+        const row = getRow();
         if (!row) {
           return '';
         }
@@ -226,12 +226,12 @@ class DiagnosticsPanel {
 
     app.commands.addCommand(CMD_JUMP_TO_DIAGNOSTIC, {
       execute: () => {
-        const row = get_row();
+        const row = getRow();
         if (!row) {
           console.warn('LPS: diagnostics row not found for jump execute()');
           return;
         }
-        this.widget.content.jump_to(row);
+        this.widget.content.jumpTo(row);
       },
       label: this.trans.__('Jump to location'),
       icon: jumpToIcon
@@ -239,7 +239,7 @@ class DiagnosticsPanel {
 
     app.commands.addCommand(CMD_COPY_DIAGNOSTIC, {
       execute: () => {
-        const row = get_row();
+        const row = getRow();
         if (!row) {
           console.warn('LPS: diagnostics row not found for copy execute()');
           return;
@@ -278,11 +278,11 @@ class DiagnosticsPanel {
     });
     app.contextMenu.addItem({
       selector: '.' + DIAGNOSTICS_LISTING_CLASS + ' tbody tr',
-      submenu: ignore_diagnostics_menu,
+      submenu: ignoreDiagnosticsMenu,
       type: 'submenu'
     });
 
-    this.is_registered = true;
+    this.isRegistered = true;
   }
 }
 

--- a/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
@@ -76,19 +76,19 @@ export const DIAGNOSTICS_PLUGIN: JupyterFrontEndPlugin<IDiagnosticsFeature> = {
           }
           feature.switchDiagnosticsPanelSource(context.adapter);
 
-          if (!diagnosticsPanel.is_registered) {
+          if (!diagnosticsPanel.isRegistered) {
             diagnosticsPanel.trans = trans;
             diagnosticsPanel.register(app);
           }
 
-          const panel_widget = diagnosticsPanel.widget;
-          if (!panel_widget.isAttached) {
-            app.shell.add(panel_widget, 'main', {
+          const panelWidget = diagnosticsPanel.widget;
+          if (!panelWidget.isAttached) {
+            app.shell.add(panelWidget, 'main', {
               ref: context.adapter.widgetId,
               mode: 'split-bottom'
             });
           }
-          app.shell.activateById(panel_widget.id);
+          app.shell.activateById(panelWidget.id);
         },
         label: trans.__('Show diagnostics panel'),
         icon: diagnosticsIcon,

--- a/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
@@ -35,7 +35,7 @@ export interface IDiagnosticsRow {
   /**
    * Cell number is the ordinal, 1-based cell identifier displayed to the user.
    */
-  cell_number?: number;
+  cellNumber?: number;
 }
 
 interface IListingContext {
@@ -46,20 +46,20 @@ interface IListingContext {
 interface IColumnOptions {
   id: string;
   label: string;
-  render_cell(data: IDiagnosticsRow, context?: IListingContext): ReactElement;
+  renderCell(data: IDiagnosticsRow, context?: IListingContext): ReactElement;
   sort(a: IDiagnosticsRow, b: IDiagnosticsRow): number;
-  is_available?(context: IListingContext): boolean;
+  isAvailable?(context: IListingContext): boolean;
 }
 
 class Column {
-  public is_visible: boolean;
+  public isVisible: boolean;
 
   constructor(private options: IColumnOptions) {
-    this.is_visible = true;
+    this.isVisible = true;
   }
 
-  render_cell(data: IDiagnosticsRow, context: IListingContext) {
-    return this.options.render_cell(data, context);
+  renderCell(data: IDiagnosticsRow, context: IListingContext) {
+    return this.options.renderCell(data, context);
   }
 
   sort(a: IDiagnosticsRow, b: IDiagnosticsRow) {
@@ -70,14 +70,14 @@ class Column {
     return this.options.id;
   }
 
-  is_available(context: IListingContext) {
-    if (this.options.is_available != null) {
-      return this.options.is_available(context);
+  isAvailable(context: IListingContext) {
+    if (this.options.isAvailable != null) {
+      return this.options.isAvailable(context);
     }
     return true;
   }
 
-  render_header(listing: DiagnosticsListing): ReactElement {
+  renderHeader(listing: DiagnosticsListing): ReactElement {
     return (
       <SortableTH
         label={this.options.label}
@@ -94,16 +94,16 @@ function SortableTH(props: {
   label: string;
   listing: DiagnosticsListing;
 }): ReactElement {
-  const is_sort_key = props.id === props.listing.sort_key;
+  const isSortKey = props.id === props.listing.sortKey;
   const sortIcon =
-    !is_sort_key || props.listing.sort_direction === 1
+    !isSortKey || props.listing.sortDirection === 1
       ? caretUpIcon
       : caretDownIcon;
   return (
     <th
       key={props.id}
       onClick={() => props.listing.sort(props.id)}
-      className={is_sort_key ? 'lsp-sorted-header' : undefined}
+      className={isSortKey ? 'lsp-sorted-header' : undefined}
       data-id={props.id}
     >
       <div>
@@ -116,20 +116,20 @@ function SortableTH(props: {
 
 export function messageWithoutCode(diagnostic: lsProtocol.Diagnostic) {
   let message = diagnostic.message;
-  let code_str = '' + diagnostic.code;
+  let codeString = '' + diagnostic.code;
   if (
     diagnostic.code != null &&
     diagnostic.code !== '' &&
-    message.startsWith(code_str + '')
+    message.startsWith(codeString + '')
   ) {
-    return message.slice(code_str.length).trim();
+    return message.slice(codeString.length).trim();
   }
   return message;
 }
 
 export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
-  sort_key = 'Severity';
-  sort_direction = 1;
+  sortKey = 'Severity';
+  sortDirection = 1;
   private _diagnostics: Map<string, IDiagnosticsRow>;
   protected trans: TranslationBundle;
   public columns: Column[];
@@ -153,7 +153,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
       new Column({
         id: 'Virtual Document',
         label: this.trans.__('Virtual Document'),
-        render_cell: (row, context: IListingContext) => (
+        renderCell: (row, context: IListingContext) => (
           <td key={0}>
             <DocumentLocator
               document={row.document}
@@ -163,12 +163,12 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
           </td>
         ),
         sort: (a, b) => a.document.idPath.localeCompare(b.document.idPath),
-        is_available: context => context.db.size > 1
+        isAvailable: context => context.db.size > 1
       }),
       new Column({
         id: 'Message',
         label: this.trans.__('Message'),
-        render_cell: row => {
+        renderCell: row => {
           let message = messageWithoutCode(row.data.diagnostic);
           return <td key={1}>{message}</td>;
         },
@@ -178,7 +178,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
       new Column({
         id: 'Code',
         label: this.trans.__('Code'),
-        render_cell: row => <td key={2}>{row.data.diagnostic.code}</td>,
+        renderCell: row => <td key={2}>{row.data.diagnostic.code}</td>,
         sort: (a, b) =>
           (a.data.diagnostic.code + '').localeCompare(
             b.data.diagnostic.source + ''
@@ -188,7 +188,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
         id: 'Severity',
         label: this.trans.__('Severity'),
         // TODO: use default diagnostic severity
-        render_cell: row => {
+        renderCell: row => {
           const severity = DiagnosticSeverity[
             row.data.diagnostic.severity || 1
           ] as keyof typeof DiagnosticSeverity;
@@ -211,7 +211,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
       new Column({
         id: 'Source',
         label: this.trans.__('Source'),
-        render_cell: row => <td key={4}>{row.data.diagnostic.source}</td>,
+        renderCell: row => <td key={4}>{row.data.diagnostic.source}</td>,
         sort: (a, b) => {
           if (!a.data.diagnostic.source) {
             return +1;
@@ -227,17 +227,17 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
       new Column({
         id: 'Cell',
         label: this.trans.__('Cell'),
-        render_cell: row => <td key={5}>{row.cell_number}</td>,
+        renderCell: row => <td key={5}>{row.cellNumber}</td>,
         sort: (a, b) =>
-          a.cell_number! - b.cell_number! ||
+          a.cellNumber! - b.cellNumber! ||
           a.data.range.start.line - b.data.range.start.line ||
           a.data.range.start.ch - b.data.range.start.ch,
-        is_available: context => context.adapter.hasMultipleEditors
+        isAvailable: context => context.adapter.hasMultipleEditors
       }),
       new Column({
         id: 'Line:Ch',
         label: this.trans.__('Line:Ch'),
-        render_cell: row => (
+        renderCell: row => (
           <td key={6}>
             {row.data.range.start.line}:{row.data.range.start.ch}
           </td>
@@ -250,26 +250,26 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
   }
 
   sort(key: string) {
-    if (key === this.sort_key) {
-      this.sort_direction = this.sort_direction * -1;
+    if (key === this.sortKey) {
+      this.sortDirection = this.sortDirection * -1;
     } else {
-      this.sort_key = key;
-      this.sort_direction = 1;
+      this.sortKey = key;
+      this.sortDirection = 1;
     }
     this.update();
   }
 
   render() {
-    let diagnostics_db = this.model.diagnostics;
+    let diagnosticsDatabase = this.model.diagnostics;
     const adapter = this.model.adapter;
-    if (diagnostics_db == null || !adapter) {
+    if (diagnosticsDatabase == null || !adapter) {
       return (
         <div className={DIAGNOSTICS_PLACEHOLDER_CLASS}>
           {this.trans.__('Diagnostics are not available')}
         </div>
       );
     }
-    if (diagnostics_db.size === 0) {
+    if (diagnosticsDatabase.size === 0) {
       return (
         <div className={DIAGNOSTICS_PLACEHOLDER_CLASS}>
           {this.trans.__('No issues detected, great job!')}
@@ -277,52 +277,52 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
       );
     }
 
-    let by_document = Array.from(diagnostics_db).map(
+    let byDocument = Array.from(diagnosticsDatabase).map(
       ([virtualDocument, diagnostics]) => {
         if (virtualDocument.isDisposed) {
           return [];
         }
-        return diagnostics.map((diagnostic_data, i) => {
-          let cell_number: number | null = null;
+        return diagnostics.map((diagnosticData, i) => {
+          let cellNumber: number | null = null;
           if (adapter.hasMultipleEditors) {
             const cellIndex = adapter.editors.findIndex(
-              value => value.ceEditor.getEditor() == diagnostic_data.editor
+              value => value.ceEditor.getEditor() == diagnosticData.editor
             );
-            cell_number = cellIndex + 1;
+            cellNumber = cellIndex + 1;
           }
           return {
-            data: diagnostic_data,
+            data: diagnosticData,
             key: virtualDocument.uri + ',' + i,
             document: virtualDocument,
-            cell_number: cell_number
+            cellNumber: cellNumber
           } as IDiagnosticsRow;
         });
       }
     );
     let flattened: IDiagnosticsRow[] = ([] as IDiagnosticsRow[]).concat.apply(
       [],
-      by_document
+      byDocument
     );
     this._diagnostics = new Map(flattened.map(row => [row.key, row]));
 
-    let sorted_column = this.columns.filter(
-      column => column.id === this.sort_key
+    let sortedColumn = this.columns.filter(
+      column => column.id === this.sortKey
     )[0];
-    let sorter = sorted_column.sort.bind(sorted_column);
-    let sorted = flattened.sort((a, b) => sorter(a, b) * this.sort_direction);
+    let sorter = sortedColumn.sort.bind(sortedColumn);
+    let sorted = flattened.sort((a, b) => sorter(a, b) * this.sortDirection);
 
     let context: IListingContext = {
-      db: diagnostics_db,
+      db: diagnosticsDatabase,
       adapter: adapter
     };
 
-    let columns_to_display = this.columns.filter(
-      column => column.is_available(context) && column.is_visible
+    let columnsToDisplay = this.columns.filter(
+      column => column.isAvailable(context) && column.isVisible
     );
 
     let elements = sorted.map(row => {
-      let cells = columns_to_display.map(column =>
-        column.render_cell(row, context)
+      let cells = columnsToDisplay.map(column =>
+        column.renderCell(row, context)
       );
 
       return (
@@ -330,7 +330,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
           key={row.key}
           data-key={row.key}
           onClick={() => {
-            this.jump_to(row);
+            this.jumpTo(row);
           }}
         >
           {cells}
@@ -338,21 +338,21 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
       );
     });
 
-    let columns_headers = columns_to_display.map(column =>
-      column.render_header(this)
+    let columnsHeaders = columnsToDisplay.map(column =>
+      column.renderHeader(this)
     );
 
     return (
       <table className={DIAGNOSTICS_LISTING_CLASS}>
         <thead>
-          <tr>{columns_headers}</tr>
+          <tr>{columnsHeaders}</tr>
         </thead>
         <tbody>{elements}</tbody>
       </table>
     );
   }
 
-  get_diagnostic(key: string): IDiagnosticsRow | undefined {
+  getDiagnostic(key: string): IDiagnosticsRow | undefined {
     if (!this._diagnostics.has(key)) {
       console.warn('Could not find the diagnostics row with key', key);
       return;
@@ -360,12 +360,12 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     return this._diagnostics.get(key);
   }
 
-  jump_to(row: IDiagnosticsRow) {
-    const cm_editor = row.data.editor;
-    cm_editor.setCursorPosition(
+  jumpTo(row: IDiagnosticsRow) {
+    const cmEditor = row.data.editor;
+    cmEditor.setCursorPosition(
       PositionConverter.cm_to_ce(row.data.range.start)
     );
-    cm_editor.focus();
+    cmEditor.focus();
   }
 }
 
@@ -379,9 +379,9 @@ export namespace DiagnosticsListing {
     settings: IFeatureSettings<LSPDiagnosticsSettings>;
     trans: TranslationBundle;
 
-    constructor(translator_bundle: TranslationBundle) {
+    constructor(translatorBundle: TranslationBundle) {
       super();
-      this.trans = translator_bundle;
+      this.trans = translatorBundle;
     }
   }
 }

--- a/packages/jupyterlab-lsp/src/features/highlights.ts
+++ b/packages/jupyterlab-lsp/src/features/highlights.ts
@@ -82,10 +82,10 @@ export class HighlightsFeature extends Feature {
       [DocumentHighlightKind.Write]: { class: 'cm-lsp-highlight-Write' }
     });
 
-    this._debouncedGetHighlight = this.create_debouncer();
+    this._debouncedGetHighlight = this.createDebouncer();
 
     this.settings.changed.connect(() => {
-      this._debouncedGetHighlight = this.create_debouncer();
+      this._debouncedGetHighlight = this.createDebouncer();
     });
 
     options.editorExtensionRegistry.addExtension({
@@ -215,15 +215,15 @@ export class HighlightsFeature extends Feature {
     }
   }
 
-  protected create_debouncer() {
+  protected createDebouncer() {
     return new Debouncer<
       lsProtocol.DocumentHighlight[] | null,
       void,
       [VirtualDocument, IVirtualPosition]
-    >(this.on_cursor_activity, this.settings.composite.debouncerDelay);
+    >(this.requestHighlights, this.settings.composite.debouncerDelay);
   }
 
-  protected on_cursor_activity = async (
+  protected requestHighlights = async (
     virtualDocument: VirtualDocument,
     virtualPosition: IVirtualPosition
   ) => {
@@ -327,13 +327,13 @@ export class HighlightsFeature extends Feature {
         return;
       }
 
-      let version_after = document.documentInfo.version;
+      let versionAfter = document.documentInfo.version;
 
       /// if document was updated since (e.g. user pressed delete - token change, but position did not)
-      if (version_after !== this._versionSent) {
+      if (versionAfter !== this._versionSent) {
         this.console.log(
           'skipping highlights response delayed by ' +
-            (version_after - this._versionSent) +
+            (versionAfter - this._versionSent) +
             ' document versions'
         );
         return;

--- a/packages/jupyterlab-lsp/src/features/rename.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/rename.spec.ts
@@ -31,7 +31,7 @@ describe('Rename', () => {
     it('renames files', async () => {
       env.activeEditor.model.sharedModel.setSource('x = 1\n');
       await env.adapter.updateDocuments();
-      let main_document = env.adapter.virtualDocument!;
+      let mainDocument = env.adapter.virtualDocument!;
 
       await feature.handleRename(
         {
@@ -50,14 +50,14 @@ describe('Rename', () => {
         'x',
         'y',
         env.adapter,
-        main_document as VirtualDocument
+        mainDocument as VirtualDocument
       );
 
       await env.adapter.updateDocuments();
 
       // TODO: intercept notifications
       // expect(env.status_message.message).toBe('Renamed x to y');
-      expect(main_document.value).toBe('y = 1\n');
+      expect(mainDocument.value).toBe('y = 1\n');
     });
   });
 });

--- a/packages/jupyterlab-lsp/src/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/features/rename.ts
@@ -82,13 +82,13 @@ export class RenameFeature extends Feature {
 
     try {
       let status: string;
-      const change_text = this._trans.__('%1 to %2', oldValue, newValue);
+      const changeText = this._trans.__('%1 to %2', oldValue, newValue);
       let severity: 'success' | 'warning' | 'error' = 'success';
 
       if (outcome.appliedChanges === 0) {
         status = this._trans.__(
           'Could not rename %1 - consult the language server documentation',
-          change_text
+          changeText
         );
         severity = 'warning';
       } else if (outcome.wasGranular) {
@@ -96,7 +96,7 @@ export class RenameFeature extends Feature {
           'Renamed %2 in %3 place',
           'Renamed %2 in %3 places',
           outcome.appliedChanges!,
-          change_text,
+          changeText,
           outcome.appliedChanges
         );
       } else if (adapter.hasMultipleEditors) {
@@ -104,11 +104,11 @@ export class RenameFeature extends Feature {
           'Renamed %2 in %3 cell',
           'Renamed %2 in %3 cells',
           outcome.modifiedCells,
-          change_text,
+          changeText,
           outcome.modifiedCells
         );
       } else {
-        status = this._trans.__('Renamed %1', change_text);
+        status = this._trans.__('Renamed %1', changeText);
       }
 
       if (outcome.errors.length !== 0) {
@@ -161,7 +161,7 @@ function guessFailureReason(
     return null;
   }
 
-  let dire_errors = [
+  let direErrors = [
     ...new Set(
       direPythonErrors.map(diagnostic => {
         let message = diagnostic.diagnostic.message;
@@ -183,7 +183,7 @@ function guessFailureReason(
       })
     )
   ].join(', ');
-  return trans.__('Syntax error(s) prevents rename: %1', dire_errors);
+  return trans.__('Syntax error(s) prevents rename: %1', direErrors);
 }
 
 export namespace RenameFeature {

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -336,7 +336,7 @@ export class SignatureFeature extends Feature {
     }
   }
 
-  protected get_markup_for_signature_help(
+  protected getMarkupForSignatureHelp(
     response: lsProtocol.SignatureHelp,
     language: Language | undefined
   ): lsProtocol.MarkupContent {
@@ -553,7 +553,7 @@ export class SignatureFeature extends Feature {
     // TODO: restore language probing
     // let language = cm_editor.getModeAt(editorPosition).name;
     const language = editorLanguage?.support?.language;
-    let markup = this.get_markup_for_signature_help(response, language);
+    let markup = this.getMarkupForSignatureHelp(response, language);
 
     this.console.debug(
       'Signature will be shown',

--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -54,15 +54,15 @@ import { LOG_CONSOLE } from './virtual/console';
 const PLUGIN_ID = PLUGIN_ID_BASE + ':plugin';
 
 export class LSPExtension {
-  get connection_manager(): ILSPDocumentConnectionManager {
-    return this._connection_manager;
+  get connectionManager(): ILSPDocumentConnectionManager {
+    return this._connectionManager;
   }
-  private _connection_manager: DocumentConnectionManager;
-  language_server_manager: ILanguageServerManager;
+  private _connectionManager: DocumentConnectionManager;
+  languageServerManager: ILanguageServerManager;
   private _settingsSchemaManager: SettingsSchemaManager;
 
   private _isAnyActive(): boolean {
-    const adapters = [...this._connection_manager.adapters.values()];
+    const adapters = [...this._connectionManager.adapters.values()];
     return (
       this.app.shell.currentWidget !== null &&
       adapters.some(adapter => adapter.widget == this.app.shell.currentWidget)
@@ -71,21 +71,21 @@ export class LSPExtension {
 
   constructor(
     public app: JupyterFrontEnd,
-    private setting_registry: ISettingRegistry,
-    connection_manager: DocumentConnectionManager,
+    private settingRegistry: ISettingRegistry,
+    connectionManager: DocumentConnectionManager,
     public console: ILSPLogConsole,
     public translator: ITranslator,
-    public user_console: ILoggerRegistry | null,
+    public userConsole: ILoggerRegistry | null,
     statusBar: IStatusBar | null,
     formRegistry: IFormRendererRegistry | null
   ) {
     const trans = (translator || nullTranslator).load('jupyterlab_lsp');
-    this.language_server_manager = connection_manager.languageServerManager;
-    this._connection_manager = connection_manager;
+    this.languageServerManager = connectionManager.languageServerManager;
+    this._connectionManager = connectionManager;
 
     const statusButtonExtension = new StatusButtonExtension({
-      languageServerManager: this.language_server_manager,
-      connectionManager: this.connection_manager,
+      languageServerManager: this.languageServerManager,
+      connectionManager: this.connectionManager,
       translatorBundle: trans,
       shell: app.shell
     });
@@ -102,8 +102,8 @@ export class LSPExtension {
     }
 
     this._settingsSchemaManager = new SettingsSchemaManager({
-      settingRegistry: this.setting_registry,
-      languageServerManager: this.language_server_manager,
+      settingRegistry: this.settingRegistry,
+      languageServerManager: this.languageServerManager,
       trans: trans,
       console: this.console.scope('SettingsSchemaManager'),
       restored: app.restored
@@ -111,9 +111,9 @@ export class LSPExtension {
 
     if (formRegistry != null) {
       const settingsUI = new SettingsUIManager({
-        settingRegistry: this.setting_registry,
+        settingRegistry: this.settingRegistry,
         console: this.console.scope('SettingsUIManager'),
-        languageServerManager: this.language_server_manager,
+        languageServerManager: this.languageServerManager,
         trans: trans,
         schemaValidated: this._settingsSchemaManager.schemaValidated
       });
@@ -130,7 +130,7 @@ export class LSPExtension {
   }
 
   private _activate(): void {
-    this.setting_registry
+    this.settingRegistry
       .load(plugin.id)
       .then(async settings => {
         await this._updateOptions(settings, false);
@@ -155,17 +155,15 @@ export class LSPExtension {
     const languageServerSettings = (options.language_servers ||
       {}) as TLanguageServerConfigurations;
 
-    this._connection_manager.initialConfigurations = languageServerSettings;
+    this._connectionManager.initialConfigurations = languageServerSettings;
     // TODO: if priorities changed reset connections
 
     // update the server-independent part of configuration immediately
-    this.connection_manager.updateConfiguration(languageServerSettings);
+    this.connectionManager.updateConfiguration(languageServerSettings);
     if (afterInitialization) {
-      this.connection_manager.updateServerConfigurations(
-        languageServerSettings
-      );
+      this.connectionManager.updateServerConfigurations(languageServerSettings);
     }
-    this._connection_manager.updateLogging(
+    this._connectionManager.updateLogging(
       options.logAllCommunication,
       options.setTrace!
     );
@@ -201,7 +199,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
   autoStart: true
 };
 
-const default_features: JupyterFrontEndPlugin<any>[] = [
+const DEFAULT_FEATURES: JupyterFrontEndPlugin<any>[] = [
   JUMP_PLUGIN,
   COMPLETION_PLUGIN,
   SIGNATURE_PLUGIN,
@@ -221,7 +219,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   FILEEDITOR_ADAPTER_PLUGIN,
   plugin,
   ...DEFAULT_TRANSCLUSIONS,
-  ...default_features
+  ...DEFAULT_FEATURES
 ];
 
 /**

--- a/packages/jupyterlab-lsp/src/overrides/maps.ts
+++ b/packages/jupyterlab-lsp/src/overrides/maps.ts
@@ -1,13 +1,13 @@
 import { ICodeOverride, replacer } from './tokens';
 
 abstract class OverridesMap extends Map<RegExp, string | replacer> {
-  protected constructor(magic_overrides: ICodeOverride[]) {
-    super(magic_overrides.map(m => [new RegExp(m.pattern), m.replacement]));
+  protected constructor(magicOverrides: ICodeOverride[]) {
+    super(magicOverrides.map(m => [new RegExp(m.pattern), m.replacement]));
   }
 
-  abstract override_for(code: string): string | null;
+  abstract overrideFor(code: string): string | null;
 
-  protected _override_for(code: string): string | null {
+  protected _overrideFor(code: string): string | null {
     for (let [key, value] of this) {
       if (code.match(key)) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -22,9 +22,9 @@ abstract class OverridesMap extends Map<RegExp, string | replacer> {
 export class ReversibleOverridesMap extends OverridesMap {
   private overrides: ICodeOverride[];
 
-  constructor(magic_overrides: ICodeOverride[]) {
-    super(magic_overrides);
-    this.overrides = magic_overrides;
+  constructor(magicOverrides: ICodeOverride[]) {
+    super(magicOverrides);
+    this.overrides = magicOverrides;
   }
 
   get reverse(): OverridesMap {
@@ -39,30 +39,30 @@ export class ReversibleOverridesMap extends OverridesMap {
     return new ReversibleOverridesMap(overrides);
   }
 
-  override_for(cell: string): string | null {
-    return super._override_for(cell);
+  overrideFor(cell: string): string | null {
+    return super._overrideFor(cell);
   }
 
-  replace_all(
-    raw_lines: string[],
+  replaceAll(
+    rawLines: string[],
     map: OverridesMap = this
   ): { lines: string[]; skipInspect: boolean[] } {
-    let substituted_lines = new Array<string>();
+    let substitutedLines = new Array<string>();
     let skipInspect = new Array<boolean>();
 
-    for (let i = 0; i < raw_lines.length; i++) {
-      let line = raw_lines[i];
-      let override = map.override_for(line);
-      substituted_lines.push(override == null ? line : override);
+    for (let i = 0; i < rawLines.length; i++) {
+      let line = rawLines[i];
+      let override = map.overrideFor(line);
+      substitutedLines.push(override == null ? line : override);
       skipInspect.push(override != null);
     }
     return {
-      lines: substituted_lines,
+      lines: substitutedLines,
       skipInspect: skipInspect
     };
   }
 
-  reverse_replace_all(raw_lines: string[]): string[] {
-    return this.replace_all(raw_lines, this.reverse).lines;
+  reverseReplaceAll(rawLines: string[]): string[] {
+    return this.replaceAll(rawLines, this.reverse).lines;
   }
 }

--- a/packages/jupyterlab-lsp/src/testutils.ts
+++ b/packages/jupyterlab-lsp/src/testutils.ts
@@ -434,18 +434,18 @@ export function codeCell(
 export function setNotebookContent(
   notebook: Notebook,
   cells: nbformat.ICodeCell[],
-  metadata = python_notebook_metadata
+  metadata = pythonNotebookMetadata
 ) {
-  let test_notebook = {
+  let testNotebook = {
     cells: cells,
     metadata: metadata
   } as nbformat.INotebookContent;
 
   notebook.model = new NotebookModel();
-  notebook.model.fromJSON(test_notebook);
+  notebook.model.fromJSON(testNotebook);
 }
 
-export const python_notebook_metadata = {
+export const pythonNotebookMetadata = {
   kernelspec: {
     display_name: 'Python [default]',
     language: 'python',
@@ -481,17 +481,4 @@ export function getCellsJSON(notebook: Notebook): Array<nbformat.ICell> {
     cells.push(notebook.model!.cells.get(i));
   }
   return cells.map(cell => cell.toJSON());
-}
-
-export async function synchronize_content(
-  environment: ITestEnvironment,
-  adapter: WidgetLSPAdapter<any>
-) {
-  await environment.adapter.updateDocuments();
-  try {
-    // TODO
-    await adapter.updateFinished;
-  } catch (e) {
-    console.warn(e);
-  }
 }

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.ts
@@ -3,7 +3,7 @@ import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 
 export const SQL_URL_PATTERN = '(?:(?:.*?)://(?:.*))';
 // note: -a/--connection_arguments and -f/--file are not supported yet
-const single_argument_options = [
+const singleArgumentOptions = [
   '--destination_table',
   '--project',
   '--use_bqstorage_api',
@@ -12,13 +12,13 @@ const single_argument_options = [
   '--verbose',
   '--params'
 ];
-const zero_argument_options = ['-l', '--connections'];
+const zeroArgumentOptions = ['-l', '--connections'];
 
 const COMMAND_PATTERN =
   '(?:' +
-  (zero_argument_options.join('|') +
+  (zeroArgumentOptions.join('|') +
     '|' +
-    single_argument_options.map(command => command + ' \\w+').join('|')) +
+    singleArgumentOptions.map(command => command + ' \\w+').join('|')) +
   ')';
 
 export let foreignCodeExtractors: IForeignCodeExtractorsRegistry = {

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/index.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/index.ts
@@ -12,10 +12,10 @@ import { foreignCodeExtractors } from './extractors';
 export const IPYTHON_BIGQUERY_TRANSCLUSIONS: JupyterFrontEndPlugin<void> = {
   id: PLUGIN_ID + ':ipython-bigquery',
   requires: [ILSPCodeExtractorsManager],
-  activate: (app, extractors_manager: ILSPCodeExtractorsManager) => {
+  activate: (app, extractorsManager: ILSPCodeExtractorsManager) => {
     for (let language of Object.keys(foreignCodeExtractors)) {
       for (let extractor of foreignCodeExtractors[language]) {
-        extractors_manager.register(extractor, language);
+        extractorsManager.register(extractor, language);
       }
     }
   },

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
@@ -70,42 +70,42 @@ describe('IPython rpy2 extractors', () => {
 
       // should not be removed, but left for the static analysis (using magic overrides)
       expect(cellCodeKept).toBe(code);
-      let r_document = getTheOnlyVirtual(foreignDocumentsMap);
-      expect(r_document.language).toBe('r');
-      expect(r_document.value).toBe('ggplot()\n');
+      let rDocument = getTheOnlyVirtual(foreignDocumentsMap);
+      expect(rDocument.language).toBe('r');
+      expect(rDocument.value).toBe('ggplot()\n');
     });
 
     it('parses input (into a dummy data frame)', () => {
       let code = wrapInPythonLines('%R -i df ggplot(df)');
       let { foreignDocumentsMap } = extract(code);
 
-      let r_document = getTheOnlyVirtual(foreignDocumentsMap);
-      expect(r_document.language).toBe('r');
-      expect(r_document.value).toBe('df <- data.frame(); ggplot(df)\n');
+      let rDocument = getTheOnlyVirtual(foreignDocumentsMap);
+      expect(rDocument.language).toBe('r');
+      expect(rDocument.value).toBe('df <- data.frame(); ggplot(df)\n');
     });
 
     it('parses input when no code is given', () => {
       let code = '%R -i df';
       let { foreignDocumentsMap } = extract(code);
 
-      let r_document = getTheOnlyVirtual(foreignDocumentsMap);
-      expect(r_document.value).toBe('df <- data.frame();\n');
+      let rDocument = getTheOnlyVirtual(foreignDocumentsMap);
+      expect(rDocument.value).toBe('df <- data.frame();\n');
     });
 
     it('parses multiple inputs (into dummy data frames)', () => {
       let code = wrapInPythonLines('%R -i df -i x ggplot(df)');
-      let { virtualDocument: r_document } = getTheOnlyPair(
+      let { virtualDocument: rDocument } = getTheOnlyPair(
         extract(code).foreignDocumentsMap
       );
-      expect(r_document.value).toBe(
+      expect(rDocument.value).toBe(
         'df <- data.frame(); x <- data.frame(); ggplot(df)\n'
       );
     });
 
     it('parses inputs ignoring other arguments', () => {
       let code = wrapInPythonLines('%R -i df --width 300 -o x ggplot(df)');
-      let r_document = getTheOnlyVirtual(extract(code).foreignDocumentsMap);
-      expect(r_document.value).toBe('df <- data.frame(); ggplot(df)\n');
+      let rDocument = getTheOnlyVirtual(extract(code).foreignDocumentsMap);
+      expect(rDocument.value).toBe('df <- data.frame(); ggplot(df)\n');
     });
   });
 
@@ -115,9 +115,9 @@ describe('IPython rpy2 extractors', () => {
       let { cellCodeKept, foreignDocumentsMap } = extract(code);
 
       expect(cellCodeKept).toBe(code);
-      let r_document = getTheOnlyVirtual(foreignDocumentsMap);
-      expect(r_document.language).toBe('r');
-      expect(r_document.value).toBe('ggplot()\n');
+      let rDocument = getTheOnlyVirtual(foreignDocumentsMap);
+      expect(rDocument.language).toBe('r');
+      expect(rDocument.value).toBe('ggplot()\n');
     });
   });
 
@@ -125,9 +125,9 @@ describe('IPython rpy2 extractors', () => {
     let code = '%%R -i df\nggplot(df)';
     let { foreignDocumentsMap } = extract(code);
 
-    let r_document = getTheOnlyVirtual(foreignDocumentsMap);
-    expect(r_document.language).toBe('r');
-    expect(r_document.value).toBe('df <- data.frame(); ggplot(df)\n');
+    let rDocument = getTheOnlyVirtual(foreignDocumentsMap);
+    expect(rDocument.language).toBe('r');
+    expect(rDocument.value).toBe('df <- data.frame(); ggplot(df)\n');
   });
 
   it('correctly gives ranges in source', () => {

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
@@ -1,15 +1,15 @@
 import { RegExpForeignCodeExtractor } from '../../extractors/regexp';
 import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 
-import { RPY2_MAX_ARGS, extract_r_args, rpy2_args_pattern } from './rpy2';
+import { RPY2_MAX_ARGS, extractArgs, argsPattern } from './rpy2';
 
-function create_rpy_code_extractor(strip_leading_space: boolean) {
-  function rpy2_code_extractor(match: string, ...args: string[]) {
-    let r = extract_r_args(args, -3);
+function createExtractor(stripLeadingSpace: boolean) {
+  function codeExtractor(match: string, ...args: string[]) {
+    let r = extractArgs(args, -3);
     let code: string;
     if (r.rest == null) {
       code = '';
-    } else if (strip_leading_space) {
+    } else if (stripLeadingSpace) {
       code = r.rest.startsWith(' ') ? r.rest.slice(1) : r.rest;
     } else {
       code = r.rest;
@@ -17,16 +17,16 @@ function create_rpy_code_extractor(strip_leading_space: boolean) {
     return code;
   }
 
-  return rpy2_code_extractor;
+  return codeExtractor;
 }
 
-let rpy2_code_extractor_non_stripping = create_rpy_code_extractor(false);
+const extractorNonStripping = createExtractor(false);
 
-function rpy2_args(match: string, ...args: string[]) {
-  let r = extract_r_args(args, -3);
+function args(match: string, ...args: string[]) {
+  let r = extractArgs(args, -3);
   // define dummy input variables using empty data frames
   let inputs = r.inputs.map(i => i + ' <- data.frame();').join(' ');
-  let code = rpy2_code_extractor_non_stripping(match, ...args);
+  let code = extractorNonStripping(match, ...args);
   if (inputs !== '' && code) {
     inputs += ' ';
   }
@@ -41,11 +41,11 @@ export let foreignCodeExtractors: IForeignCodeExtractorsRegistry = {
     //
     new RegExpForeignCodeExtractor({
       language: 'r',
-      pattern: '^%%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + '\n([^]*)',
+      pattern: '^%%R' + argsPattern(RPY2_MAX_ARGS) + '\n([^]*)',
       foreignCaptureGroups: [RPY2_MAX_ARGS * 2 + 1],
       // it is important to not strip any leading spaces
-      foreignReplacer: rpy2_code_extractor_non_stripping,
-      extractArguments: rpy2_args,
+      foreignReplacer: extractorNonStripping,
+      extractArguments: args,
       isStandalone: false,
       fileExtension: 'R'
     }),
@@ -53,11 +53,10 @@ export let foreignCodeExtractors: IForeignCodeExtractorsRegistry = {
       language: 'r',
       // it is very important to not include the space which will be trimmed in the capture group,
       // otherwise the offset will be off by one and the R language server will crash
-      pattern:
-        '(?:^|\n)%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + '(?: (.*))?(?:\n|$)',
+      pattern: '(?:^|\n)%R' + argsPattern(RPY2_MAX_ARGS) + '(?: (.*))?(?:\n|$)',
       foreignCaptureGroups: [RPY2_MAX_ARGS * 2 + 1],
-      foreignReplacer: create_rpy_code_extractor(true),
-      extractArguments: rpy2_args,
+      foreignReplacer: createExtractor(true),
+      extractArguments: args,
       isStandalone: false,
       fileExtension: 'R'
     })

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/index.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/index.ts
@@ -12,16 +12,16 @@ export const IPYTHON_RPY2_TRANSCLUSIONS: JupyterFrontEndPlugin<void> = {
   requires: [ILSPCodeExtractorsManager, ILSPCodeOverridesManager],
   activate: (
     app,
-    extractors_manager: ILSPCodeExtractorsManager,
-    overrides_manager: ILSPCodeOverridesManager
+    extractorsMmanager: ILSPCodeExtractorsManager,
+    overridesManager: ILSPCodeOverridesManager
   ) => {
     for (let language of Object.keys(foreignCodeExtractors)) {
       for (let extractor of foreignCodeExtractors[language]) {
-        extractors_manager.register(extractor, language);
+        extractorsMmanager.register(extractor, language);
       }
     }
     for (let override of overrides) {
-      overrides_manager.register(override, 'python');
+      overridesManager.register(override, 'python');
     }
   },
   autoStart: true

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.spec.ts
@@ -8,109 +8,109 @@ print(1)
 
 describe('rpy2 IPython overrides', () => {
   describe('rpy2 cell magics', () => {
-    let cell_magics = new ReversibleOverridesMap(
+    let cellMagics = new ReversibleOverridesMap(
       overrides.filter(override => override.scope == 'cell')
     );
     it('overrides cell magic', () => {
-      let override = cell_magics.override_for(R_CELL_MAGIC)!;
+      let override = cellMagics.overrideFor(R_CELL_MAGIC)!;
       expect(override).toBe(
         'rpy2.ipython.rmagic.RMagics.R("""print(1)\n""", "")'
       );
-      let reverse = cell_magics.reverse.override_for(override);
+      let reverse = cellMagics.reverse.overrideFor(override);
       expect(reverse).toBe(R_CELL_MAGIC);
 
-      override = cell_magics.override_for('%%R -i x -o y\nsome\ncode')!;
+      override = cellMagics.overrideFor('%%R -i x -o y\nsome\ncode')!;
       expect(override).toBe(
         'y = rpy2.ipython.rmagic.RMagics.R("""some\ncode""", "", x)'
       );
-      reverse = cell_magics.reverse.override_for(override);
+      reverse = cellMagics.reverse.overrideFor(override);
       expect(reverse).toBe('%%R -i x -o y\nsome\ncode');
     });
   });
 
   describe('rpy2 line magics', () => {
-    let line_magics = new ReversibleOverridesMap(
+    let lineMagics = new ReversibleOverridesMap(
       overrides.filter(override => override.scope == 'line')
     );
 
     it('works with other Rdevice', () => {
       let line = '%Rdevice svg';
-      let override = line_magics.override_for(line)!;
+      let override = lineMagics.overrideFor(line)!;
       expect(override).toBe('rpy2.ipython.rmagic.RMagics.Rdevice(" svg", "")');
-      let reverse = line_magics.reverse.override_for(override);
+      let reverse = lineMagics.reverse.overrideFor(override);
       expect(reverse).toBe(line);
     });
 
     it('does not overwrite non-rpy2 magics', () => {
       let line = '%RestMagic';
-      let override = line_magics.override_for(line);
+      let override = lineMagics.overrideFor(line);
       expect(override).toBe(null);
     });
 
     it('works with the short form arguments, inputs and outputs', () => {
       let line = '%R -i x';
-      let override = line_magics.override_for(line)!;
+      let override = lineMagics.overrideFor(line)!;
       expect(override).toBe('rpy2.ipython.rmagic.RMagics.R("", "", x)');
-      let reverse = line_magics.reverse.override_for(override);
+      let reverse = lineMagics.reverse.overrideFor(override);
       expect(reverse).toBe(line);
 
       line = '%R -o x';
-      override = line_magics.override_for(line)!;
+      override = lineMagics.overrideFor(line)!;
       expect(override).toBe('x = rpy2.ipython.rmagic.RMagics.R("", "")');
-      reverse = line_magics.reverse.override_for(override);
+      reverse = lineMagics.reverse.overrideFor(override);
       expect(reverse).toBe(line);
 
       line = '%R -i x command()';
-      override = line_magics.override_for(line)!;
+      override = lineMagics.overrideFor(line)!;
       expect(override).toBe(
         'rpy2.ipython.rmagic.RMagics.R(" command()", "", x)'
       );
-      reverse = line_magics.reverse.override_for(override);
+      reverse = lineMagics.reverse.overrideFor(override);
       expect(reverse).toBe(line);
 
       line = '%R -i x -w 800 -h 400 command()';
-      override = line_magics.override_for(line)!;
+      override = lineMagics.overrideFor(line)!;
       expect(override).toBe(
         'rpy2.ipython.rmagic.RMagics.R(" command()", "-w 800 -h 400", x)'
       );
-      reverse = line_magics.reverse.override_for(override);
+      reverse = lineMagics.reverse.overrideFor(override);
       expect(reverse).toBe(line);
 
       line = '%R -i x -o y -i z command()';
-      override = line_magics.override_for(line)!;
+      override = lineMagics.overrideFor(line)!;
       expect(override).toBe(
         'y = rpy2.ipython.rmagic.RMagics.R(" command()", "", x, z)'
       );
 
       line = '%R -i x -i z -o y -o w command()';
-      override = line_magics.override_for(line)!;
+      override = lineMagics.overrideFor(line)!;
       expect(override).toBe(
         'y, w = rpy2.ipython.rmagic.RMagics.R(" command()", "", x, z)'
       );
-      reverse = line_magics.reverse.override_for(override);
+      reverse = lineMagics.reverse.overrideFor(override);
       expect(reverse).toBe(line);
     });
 
     it('does not substitute magic-like constructs', () => {
       let line = 'print("%R -i x")';
-      let override = line_magics.override_for(line);
+      let override = lineMagics.overrideFor(line);
       expect(override).toBe(null);
     });
 
     it('works with the long form arguments', () => {
       let line = '%R --input x';
-      let override = line_magics.override_for(line)!;
+      let override = lineMagics.overrideFor(line)!;
       expect(override).toBe('rpy2.ipython.rmagic.RMagics.R("", "", x)');
-      let reverse = line_magics.reverse.override_for(override);
+      let reverse = lineMagics.reverse.overrideFor(override);
       // TODO: make this preserve the long form
       expect(reverse).toBe('%R -i x');
 
       line = '%R --width 800 --height 400 command()';
-      override = line_magics.override_for(line)!;
+      override = lineMagics.overrideFor(line)!;
       expect(override).toBe(
         'rpy2.ipython.rmagic.RMagics.R(" command()", "--width 800 --height 400")'
       );
-      reverse = line_magics.reverse.override_for(override);
+      reverse = lineMagics.reverse.overrideFor(override);
       expect(reverse).toBe(line);
     });
   });

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.ts
@@ -3,22 +3,19 @@ import { LINE_MAGIC_PREFIX } from '../ipython/overrides';
 
 import {
   RPY2_MAX_ARGS,
-  parse_r_args,
-  rpy2_args_pattern,
-  rpy2_reverse_pattern,
-  rpy2_reverse_replacement
+  parseArgs,
+  argsPattern,
+  reversePattern,
+  reverseReplacement
 } from './rpy2';
 
 export let overrides: IScopedCodeOverride[] = [
   {
     // support up to 10 arguments
     pattern:
-      LINE_MAGIC_PREFIX +
-      '%R' +
-      rpy2_args_pattern(RPY2_MAX_ARGS) +
-      '( .*)?(\n|$)',
+      LINE_MAGIC_PREFIX + '%R' + argsPattern(RPY2_MAX_ARGS) + '( .*)?(\n|$)',
     replacement: (match, prefix, ...args) => {
-      let r = parse_r_args(args, -4);
+      let r = parseArgs(args, -4);
       // note: only supports assignment or -o/--output, not both
       // TODO assignment like in x = %R 1 should be distinguished from -o
       return `${prefix}${r.outputs}rpy2.ipython.rmagic.RMagics.R("${
@@ -27,9 +24,9 @@ export let overrides: IScopedCodeOverride[] = [
     },
     scope: 'line',
     reverse: {
-      pattern: rpy2_reverse_pattern(),
+      pattern: reversePattern(),
       replacement: (match, ...args) => {
-        let r = rpy2_reverse_replacement(match, ...args);
+        let r = reverseReplacement(match, ...args);
         return '%R' + r.input + r.output + r.other + r.contents;
       },
       scope: 'line'
@@ -38,16 +35,16 @@ export let overrides: IScopedCodeOverride[] = [
   // rpy2 extension R magic - this should likely go as an example to the user documentation, rather than being a default
   //   only handles simple one input - one output case
   {
-    pattern: '^%%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + '(\n)?([\\s\\S]*)',
+    pattern: '^%%R' + argsPattern(RPY2_MAX_ARGS) + '(\n)?([\\s\\S]*)',
     replacement: (match, ...args) => {
-      let r = parse_r_args(args, -3);
+      let r = parseArgs(args, -3);
       return `${r.outputs}rpy2.ipython.rmagic.RMagics.R("""${r.content}""", "${r.others}"${r.inputs})`;
     },
     scope: 'cell',
     reverse: {
-      pattern: rpy2_reverse_pattern('"""', true),
+      pattern: reversePattern('"""', true),
       replacement: (match, ...args) => {
-        let r = rpy2_reverse_replacement(match, ...args);
+        let r = reverseReplacement(match, ...args);
         return '%%R' + r.input + r.output + r.other + '\n' + r.contents;
       },
       scope: 'cell'
@@ -60,9 +57,9 @@ export let overrides: IScopedCodeOverride[] = [
     },
     scope: 'line',
     reverse: {
-      pattern: rpy2_reverse_pattern('"', false, 'Rdevice'),
+      pattern: reversePattern('"', false, 'Rdevice'),
       replacement: (match, ...args) => {
-        let r = rpy2_reverse_replacement(match, ...args);
+        let r = reverseReplacement(match, ...args);
         return '%Rdevice' + r.input + r.output + r.other + r.contents;
       },
       scope: 'line'

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/rpy2.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/rpy2.ts
@@ -1,6 +1,6 @@
 export const RPY2_MAX_ARGS = 10;
 
-export function extract_r_args(args: string[], content_position: number) {
+export function extractArgs(args: string[], contentPosition: number) {
   let inputs = [];
   let outputs = [];
   let others = [];
@@ -20,35 +20,32 @@ export function extract_r_args(args: string[], content_position: number) {
   return {
     inputs: inputs,
     outputs: outputs,
-    rest: args[args.length + content_position],
+    rest: args[args.length + contentPosition],
     others: others
   };
 }
 
-export function parse_r_args(args: string[], content_position: number) {
-  let { inputs, outputs, rest, others } = extract_r_args(
-    args,
-    content_position
-  );
-  let input_variables = inputs.join(', ');
-  if (input_variables) {
-    input_variables = ', ' + input_variables;
+export function parseArgs(args: string[], contentPosition: number) {
+  let { inputs, outputs, rest, others } = extractArgs(args, contentPosition);
+  let inputVariables = inputs.join(', ');
+  if (inputVariables) {
+    inputVariables = ', ' + inputVariables;
   }
-  let output_variables = outputs.join(', ');
-  if (output_variables) {
-    output_variables = output_variables + ' = ';
+  let outputVariables = outputs.join(', ');
+  if (outputVariables) {
+    outputVariables = outputVariables + ' = ';
   }
   return {
     content: rest,
     others: others.join(' '),
-    inputs: input_variables,
-    outputs: output_variables
+    inputs: inputVariables,
+    outputs: outputVariables
   };
 }
 
-export function rpy2_reverse_pattern(
+export function reversePattern(
   quote = '"',
-  multi_line = false,
+  multiLine = false,
   magic = 'R'
 ): string {
   return (
@@ -58,7 +55,7 @@ export function rpy2_reverse_pattern(
     magic +
     '\\(' +
     quote +
-    (multi_line ? '([\\s\\S]*)' : '(.*?)') +
+    (multiLine ? '([\\s\\S]*)' : '(.*?)') +
     quote +
     ', "(.*?)"' +
     '(?:, (\\S+))?'.repeat(10) +
@@ -66,7 +63,7 @@ export function rpy2_reverse_pattern(
   );
 }
 
-export function rpy2_reverse_replacement(match: string, ...args: string[]) {
+export function reverseReplacement(match: string, ...args: string[]) {
   let outputs = [];
   for (let i = 0; i < 10; i++) {
     if (args[i] == null) {
@@ -81,27 +78,27 @@ export function rpy2_reverse_replacement(match: string, ...args: string[]) {
     }
     inputs.push(args[i]);
   }
-  let input_variables = inputs.join(' -i ');
-  if (input_variables) {
-    input_variables = ' -i ' + input_variables;
+  let inputVariables = inputs.join(' -i ');
+  if (inputVariables) {
+    inputVariables = ' -i ' + inputVariables;
   }
-  let output_variables = outputs.join(' -o ');
-  if (output_variables) {
-    output_variables = ' -o ' + output_variables;
+  let outputVariables = outputs.join(' -o ');
+  if (outputVariables) {
+    outputVariables = ' -o ' + outputVariables;
   }
   let contents = args[11];
-  let other_args = args[12];
-  if (other_args) {
-    other_args = ' ' + other_args;
+  let otherArgs = args[12];
+  if (otherArgs) {
+    otherArgs = ' ' + otherArgs;
   }
   return {
-    input: input_variables,
-    output: output_variables,
-    other: other_args,
+    input: inputVariables,
+    output: outputVariables,
+    other: otherArgs,
     contents: contents
   };
 }
 
-export function rpy2_args_pattern(max_n: number) {
-  return '(?: -(\\S+) (\\S+))?'.repeat(max_n);
+export function argsPattern(maxN: number) {
+  return '(?: -(\\S+) (\\S+))?'.repeat(maxN);
 }

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.spec.ts
@@ -33,7 +33,7 @@ describe('IPython SQL extractors', () => {
 
   describe('SQL url pattern', () => {
     it('matches connection strings', () => {
-      const correct_urls = [
+      const correctUrls = [
         'mysql+pymysql://scott:tiger@localhost/foo',
         'oracle://scott:tiger@127.0.0.1:1521/sidname',
         'sqlite://',
@@ -42,7 +42,7 @@ describe('IPython SQL extractors', () => {
         'impala://hserverhost:port/default?kerberos_service_name=hive&auth_mechanism=GSSAPI'
       ];
       const pattern = new RegExp(SQL_URL_PATTERN);
-      for (let url of correct_urls) {
+      for (let url of correctUrls) {
         expect(pattern.test(url)).toBe(true);
       }
     });

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.ts
@@ -3,7 +3,7 @@ import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 
 export const SQL_URL_PATTERN = '(?:(?:.*?)://(?:.*))';
 // note: -a/--connection_arguments and -f/--file are not supported yet
-const single_argument_options = [
+const singleArgumentOptions = [
   '-x',
   '--close',
   '-c',
@@ -12,13 +12,13 @@ const single_argument_options = [
   '--persist',
   '--append'
 ];
-const zero_argument_options = ['-l', '--connections'];
+const zeroArgumentOptions = ['-l', '--connections'];
 
 const COMMAND_PATTERN =
   '(?:' +
-  (zero_argument_options.join('|') +
+  (zeroArgumentOptions.join('|') +
     '|' +
-    single_argument_options.map(command => command + ' \\w+').join('|')) +
+    singleArgumentOptions.map(command => command + ' \\w+').join('|')) +
   ')';
 
 export let foreignCodeExtractors: IForeignCodeExtractorsRegistry = {

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/index.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/index.ts
@@ -14,10 +14,10 @@ import { foreignCodeExtractors } from './extractors';
 export const IPYTHON_SQL_TRANSCLUSIONS: JupyterFrontEndPlugin<void> = {
   id: PLUGIN_ID + ':ipython-sql',
   requires: [ILSPCodeExtractorsManager],
-  activate: (app, extractors_manager: ILSPCodeExtractorsManager) => {
+  activate: (app, extractorsManager: ILSPCodeExtractorsManager) => {
     for (let language of Object.keys(foreignCodeExtractors)) {
       for (let extractor of foreignCodeExtractors[language]) {
-        extractors_manager.register(extractor, language);
+        extractorsManager.register(extractor, language);
       }
     }
   },

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.spec.ts
@@ -36,9 +36,9 @@ describe('IPython extractors', () => {
       let { cellCodeKept, foreignDocumentsMap } = extract(code);
 
       expect(cellCodeKept).toBe(code);
-      let python_document = getTheOnlyVirtual(foreignDocumentsMap);
-      expect(python_document.language).toBe('python');
-      expect(python_document.value).toBe('sys.exit()\n');
+      let pythonDocument = getTheOnlyVirtual(foreignDocumentsMap);
+      expect(pythonDocument.language).toBe('python');
+      expect(pythonDocument.value).toBe('sys.exit()\n');
     });
   });
 
@@ -47,18 +47,18 @@ describe('IPython extractors', () => {
       let code = '%%html\n<div>safe</div>';
       let { foreignDocumentsMap } = extract(code);
 
-      let html_document = getTheOnlyVirtual(foreignDocumentsMap);
-      expect(html_document.language).toBe('html');
-      expect(html_document.value).toBe('<div>safe</div>\n');
+      let htmlDocument = getTheOnlyVirtual(foreignDocumentsMap);
+      expect(htmlDocument.language).toBe('html');
+      expect(htmlDocument.value).toBe('<div>safe</div>\n');
     });
 
     it('works with html in isolated mode', () => {
       let code = '%%html --isolated\n<div>dangerous</div>';
       let { foreignDocumentsMap } = extract(code);
 
-      let html_document = getTheOnlyVirtual(foreignDocumentsMap);
-      expect(html_document.language).toBe('html');
-      expect(html_document.value).toBe('<div>dangerous</div>\n');
+      let htmlDocument = getTheOnlyVirtual(foreignDocumentsMap);
+      expect(htmlDocument.language).toBe('html');
+      expect(htmlDocument.value).toBe('<div>dangerous</div>\n');
     });
   });
 });

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/index.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/index.ts
@@ -12,16 +12,16 @@ export const IPYTHON_TRANSCLUSIONS: JupyterFrontEndPlugin<void> = {
   requires: [ILSPCodeExtractorsManager, ILSPCodeOverridesManager],
   activate: (
     app,
-    extractors_manager: ILSPCodeExtractorsManager,
-    overrides_manager: ILSPCodeOverridesManager
+    extractorsManager: ILSPCodeExtractorsManager,
+    overrideManager: ILSPCodeOverridesManager
   ) => {
     for (let language of Object.keys(foreignCodeExtractors)) {
       for (let extractor of foreignCodeExtractors[language]) {
-        extractors_manager.register(extractor, language);
+        extractorsManager.register(extractor, language);
       }
     }
     for (let override of overrides) {
-      overrides_manager.register(override, 'python');
+      overrideManager.register(override, 'python');
     }
   },
   autoStart: true

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
@@ -33,201 +33,201 @@ const LINE_MAGIC_WITH_SPACE = `%MAGIC line = dd`;
 
 describe('Default IPython overrides', () => {
   describe('IPython cell magics', () => {
-    let cell_magics_map = new ReversibleOverridesMap(
+    let cellMagicsMap = new ReversibleOverridesMap(
       overrides.filter(override => override.scope == 'cell')
     );
     it('overrides cell magics', () => {
-      let override = cell_magics_map.override_for(CELL_MAGIC_EXISTS)!;
+      let override = cellMagicsMap.overrideFor(CELL_MAGIC_EXISTS)!;
       expect(override).toBe(
         'get_ipython().run_cell_magic("MAGIC", "", """some text\n""")'
       );
 
-      let reverse = cell_magics_map.reverse.override_for(override);
+      let reverse = cellMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe(CELL_MAGIC_EXISTS);
     });
 
     it('works for empty cells', () => {
       // those are not correct syntax, but will happen when users are in the process of writing
-      const cell_magic_with_args = '%%MAGIC\n';
-      let override = cell_magics_map.override_for(cell_magic_with_args)!;
+      const cellMagicWithArgs = '%%MAGIC\n';
+      let override = cellMagicsMap.overrideFor(cellMagicWithArgs)!;
       expect(override).toBe(
         'get_ipython().run_cell_magic("MAGIC", "", """""")'
       );
 
-      let reverse = cell_magics_map.reverse.override_for(override);
-      expect(reverse).toBe(cell_magic_with_args);
+      let reverse = cellMagicsMap.reverse.overrideFor(override);
+      expect(reverse).toBe(cellMagicWithArgs);
     });
 
     it('escapes arguments in the first line', () => {
-      const cell_magic_with_args = '%%MAGIC "arg in quotes"\ntext';
-      let override = cell_magics_map.override_for(cell_magic_with_args)!;
+      const cellMagicWithArgs = '%%MAGIC "arg in quotes"\ntext';
+      let override = cellMagicsMap.overrideFor(cellMagicWithArgs)!;
       expect(override).toBe(
         'get_ipython().run_cell_magic("MAGIC", " \\"arg in quotes\\"", """text""")'
       );
 
-      let reverse = cell_magics_map.reverse.override_for(override);
-      expect(reverse).toBe(cell_magic_with_args);
+      let reverse = cellMagicsMap.reverse.overrideFor(override);
+      expect(reverse).toBe(cellMagicWithArgs);
     });
 
     it('escapes docstrings properly', () => {
-      let override = cell_magics_map.override_for(CELL_MAGIC_WITH_DOCSTRINGS)!;
+      let override = cellMagicsMap.overrideFor(CELL_MAGIC_WITH_DOCSTRINGS)!;
       expect(override).toBe(
         'get_ipython().run_cell_magic("MAGIC", "", """' +
           ESCAPED_TEXT_WITH_DOCSTRINGS +
           '""")'
       );
 
-      let reverse = cell_magics_map.reverse.override_for(override);
+      let reverse = cellMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe(CELL_MAGIC_WITH_DOCSTRINGS);
     });
 
     it('does not override cell-magic-like constructs', () => {
-      let override = cell_magics_map.override_for(NO_CELL_MAGIC);
+      let override = cellMagicsMap.overrideFor(NO_CELL_MAGIC);
       expect(override).toBe(null);
 
-      override = cell_magics_map.override_for(LINE_MAGIC_WITH_SPACE);
+      override = cellMagicsMap.overrideFor(LINE_MAGIC_WITH_SPACE);
       expect(override).toBe(null);
     });
   });
 
   describe('IPython line magics', () => {
-    let line_magics_map = new ReversibleOverridesMap(
+    let lineMagicsMap = new ReversibleOverridesMap(
       overrides.filter(override => override.scope == 'line')
     );
     it('overrides line magics', () => {
-      let override = line_magics_map.override_for(LINE_MAGIC_WITH_SPACE)!;
+      let override = lineMagicsMap.overrideFor(LINE_MAGIC_WITH_SPACE)!;
       expect(override).toBe(
         'get_ipython().run_line_magic("MAGIC", " line = dd")'
       );
 
-      let reverse = line_magics_map.reverse.override_for(override);
+      let reverse = lineMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe(LINE_MAGIC_WITH_SPACE);
     });
 
     it('overrides x =%ls and x = %ls', () => {
       // this is a corner-case as described in
       // https://github.com/jupyter-lsp/jupyterlab-lsp/issues/281#issuecomment-645286076
-      let override = line_magics_map.override_for('x =%ls');
+      let override = lineMagicsMap.overrideFor('x =%ls');
       expect(override).toBe('x =get_ipython().run_line_magic("ls", "")');
 
-      override = line_magics_map.override_for('x = %ls');
+      override = lineMagicsMap.overrideFor('x = %ls');
       expect(override).toBe('x = get_ipython().run_line_magic("ls", "")');
     });
 
     it('does not override line-magic-like constructs', () => {
-      let override = line_magics_map.override_for('list("%")');
+      let override = lineMagicsMap.overrideFor('list("%")');
       expect(override).toBe(null);
 
-      override = line_magics_map.override_for('list(" %test")');
+      override = lineMagicsMap.overrideFor('list(" %test")');
       expect(override).toBe(null);
     });
 
     it('does not override modulo operators', () => {
-      let override = line_magics_map.override_for('3 % 2');
+      let override = lineMagicsMap.overrideFor('3 % 2');
       expect(override).toBe(null);
 
-      override = line_magics_map.override_for('3%2');
+      override = lineMagicsMap.overrideFor('3%2');
       expect(override).toBe(null);
     });
 
     it('escapes arguments', () => {
-      let line_magic_with_args = '%MAGIC "arg"';
-      let override = line_magics_map.override_for(line_magic_with_args)!;
+      let lineMagicWithArgs = '%MAGIC "arg"';
+      let override = lineMagicsMap.overrideFor(lineMagicWithArgs)!;
       expect(override).toBe(
         'get_ipython().run_line_magic("MAGIC", " \\"arg\\"")'
       );
 
-      let reverse = line_magics_map.reverse.override_for(override);
-      expect(reverse).toBe(line_magic_with_args);
+      let reverse = lineMagicsMap.reverse.overrideFor(override);
+      expect(reverse).toBe(lineMagicWithArgs);
 
-      line_magic_with_args = '%MAGIC "arg\\"';
-      override = line_magics_map.override_for(line_magic_with_args)!;
+      lineMagicWithArgs = '%MAGIC "arg\\"';
+      override = lineMagicsMap.overrideFor(lineMagicWithArgs)!;
       expect(override).toBe(
         'get_ipython().run_line_magic("MAGIC", " \\"arg\\\\\\"")'
       );
 
-      reverse = line_magics_map.reverse.override_for(override);
-      expect(reverse).toBe(line_magic_with_args);
+      reverse = lineMagicsMap.reverse.overrideFor(override);
+      expect(reverse).toBe(lineMagicWithArgs);
     });
 
     it('overrides shell commands', () => {
-      let override = line_magics_map.override_for('!ls -o')!;
+      let override = lineMagicsMap.overrideFor('!ls -o')!;
       expect(override).toBe('get_ipython().getoutput("ls -o")')!;
 
-      let reverse = line_magics_map.reverse.override_for(override);
+      let reverse = lineMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe('!ls -o');
     });
 
     it('overrides shell commands assignments: x =!ls and x = !ls', () => {
-      let override = line_magics_map.override_for('x =!ls');
+      let override = lineMagicsMap.overrideFor('x =!ls');
       expect(override).toBe('x =get_ipython().getoutput("ls")');
 
-      override = line_magics_map.override_for('x = !ls');
+      override = lineMagicsMap.overrideFor('x = !ls');
       expect(override).toBe('x = get_ipython().getoutput("ls")');
     });
 
     it('does not override shell-like constructs', () => {
-      let override = line_magics_map.override_for('"!ls"');
+      let override = lineMagicsMap.overrideFor('"!ls"');
       expect(override).toBe(null);
     });
 
     it('does not override != comparisons', () => {
-      let override = line_magics_map.override_for('1 != None');
+      let override = lineMagicsMap.overrideFor('1 != None');
       expect(override).toBe(null);
     });
   });
 
   describe('IPython help line magics', () => {
-    let line_magics_map = new ReversibleOverridesMap(
+    let lineMagicsMap = new ReversibleOverridesMap(
       overrides.filter(override => override.scope == 'line')
     );
 
     it('overrides pinfo', () => {
-      let override = line_magics_map.override_for('?int')!;
+      let override = lineMagicsMap.overrideFor('?int')!;
       expect(override).toBe("get_ipython().run_line_magic('pinfo', 'int')");
 
-      let reverse = line_magics_map.reverse.override_for(override);
+      let reverse = lineMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe('?int');
 
-      override = line_magics_map.override_for('int?')!;
+      override = lineMagicsMap.overrideFor('int?')!;
       expect(override).toBe("get_ipython().run_line_magic('pinfo',  'int')");
 
-      reverse = line_magics_map.reverse.override_for(override);
+      reverse = lineMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe('int?');
     });
 
     it('overrides pinfo2', () => {
-      let override = line_magics_map.override_for('??int')!;
+      let override = lineMagicsMap.overrideFor('??int')!;
       expect(override).toBe("get_ipython().run_line_magic('pinfo2', 'int')");
 
-      let reverse = line_magics_map.reverse.override_for(override);
+      let reverse = lineMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe('??int');
 
-      override = line_magics_map.override_for('int??')!;
+      override = lineMagicsMap.overrideFor('int??')!;
       expect(override).toBe("get_ipython().run_line_magic('pinfo2',  'int')");
 
-      reverse = line_magics_map.reverse.override_for(override);
+      reverse = lineMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe('int??');
 
-      override = line_magics_map.override_for('some_func??')!;
+      override = lineMagicsMap.overrideFor('some_func??')!;
       expect(override).toBe(
         "get_ipython().run_line_magic('pinfo2',  'some_func')"
       );
-      reverse = line_magics_map.reverse.override_for(override);
+      reverse = lineMagicsMap.reverse.overrideFor(override);
       expect(reverse).toBe('some_func??');
     });
 
     it('does not override standalone question marks', () => {
-      let override = line_magics_map.override_for("'q?'");
+      let override = lineMagicsMap.overrideFor("'q?'");
       expect(override).toBe(null);
 
-      override = line_magics_map.override_for('#?');
+      override = lineMagicsMap.overrideFor('#?');
       expect(override).toBe(null);
 
-      override = line_magics_map.override_for("?q'");
+      override = lineMagicsMap.overrideFor("?q'");
       expect(override).toBe(null);
 
-      override = line_magics_map.override_for("?#'");
+      override = lineMagicsMap.overrideFor("?#'");
       expect(override).toBe(null);
     });
   });

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
@@ -8,7 +8,7 @@ function unescape(x: string) {
   return x.replace(/\\([\\"])/g, '$1');
 }
 
-function empty_or_escaped(x: string) {
+function emptyOrEscaped(x: string) {
   if (!x) {
     return '';
   } else {
@@ -66,11 +66,11 @@ export let overrides: IScopedCodeOverride[] = [
     //    ?x['a']
     // would not be solved, leading to "Object `x['a']` not found."
     pattern: '^(\\s*)' + '(\\?{1,2})' + PYTHON_IDENTIFIER + '(\n)?$',
-    replacement: (match, prefix, marks, name, line_break) => {
+    replacement: (match, prefix, marks, name, lineBreak) => {
       const cmd = marks == '?' ? 'pinfo' : 'pinfo2';
-      line_break = line_break || '';
+      lineBreak = lineBreak || '';
       // trick: use single quotes to distinguish
-      return `${prefix}get_ipython().run_line_magic(\'${cmd}\', \'${name}\')${line_break}`;
+      return `${prefix}get_ipython().run_line_magic(\'${cmd}\', \'${name}\')${lineBreak}`;
     },
     scope: 'line',
     reverse: {
@@ -85,11 +85,11 @@ export let overrides: IScopedCodeOverride[] = [
   },
   {
     pattern: '^(\\s*)' + PYTHON_IDENTIFIER + '(\\?{1,2})(\n)?',
-    replacement: (match, prefix, name, marks, line_break) => {
+    replacement: (match, prefix, name, marks, lineBreak) => {
       const cmd = marks == '?' ? 'pinfo' : 'pinfo2';
-      line_break = line_break || '';
+      lineBreak = lineBreak || '';
       // trick: use two spaces to distinguish pinfo using suffix (int?) from the one using prefix (?int)
-      return `${prefix}get_ipython().run_line_magic(\'${cmd}\',  \'${name}\')${line_break}`;
+      return `${prefix}get_ipython().run_line_magic(\'${cmd}\',  \'${name}\')${lineBreak}`;
     },
     scope: 'line',
     reverse: {
@@ -104,10 +104,10 @@ export let overrides: IScopedCodeOverride[] = [
   },
   {
     pattern: LINE_MAGIC_PREFIX + '%(\\S+)(.*)(\n)?',
-    replacement: (match, prefix, name, args, line_break) => {
-      args = empty_or_escaped(args);
-      line_break = line_break || '';
-      return `${prefix}get_ipython().run_line_magic("${name}", "${args}")${line_break}`;
+    replacement: (match, prefix, name, args, lineBreak) => {
+      args = emptyOrEscaped(args);
+      lineBreak = lineBreak || '';
+      return `${prefix}get_ipython().run_line_magic("${name}", "${args}")${lineBreak}`;
     },
     scope: 'line',
     reverse: {
@@ -124,14 +124,14 @@ export let overrides: IScopedCodeOverride[] = [
    */
   {
     pattern: '^%%(\\S+)(.*\n)([\\s\\S]*)',
-    replacement: (match, name, first_line, content, offset, entire) => {
-      first_line = empty_or_escaped(first_line);
-      if (first_line) {
+    replacement: (match, name, firstLine, content, offset, entire) => {
+      firstLine = emptyOrEscaped(firstLine);
+      if (firstLine) {
         // remove the new line
-        first_line = first_line.slice(0, -1);
+        firstLine = firstLine.slice(0, -1);
       }
       content = content.replace(/"""/g, '\\"\\"\\"');
-      return `get_ipython().run_cell_magic("${name}", "${first_line}", """${content}""")`;
+      return `get_ipython().run_cell_magic("${name}", "${firstLine}", """${content}""")`;
     },
     scope: 'cell',
     reverse: {

--- a/packages/jupyterlab-lsp/src/utils.spec.ts
+++ b/packages/jupyterlab-lsp/src/utils.spec.ts
@@ -1,8 +1,8 @@
-import { collapseToDotted, escapeMarkdown, uris_equal } from './utils';
+import { collapseToDotted, escapeMarkdown, urisEqual } from './utils';
 
 describe('uris_equal', () => {
   it('should workaround Windows paths/Pyright issues', () => {
-    const result = uris_equal(
+    const result = urisEqual(
       'file:///d%3A/a/jupyterlab-lsp/jupyterlab-lsp/atest/output/windows_39_4/home/n%C3%B6te%20b%C3%B2%C3%B3ks/example.py',
       'file:///d:/a/jupyterlab-lsp/jupyterlab-lsp/atest/output/windows_39_4/home/n%C3%B6te%20b%C3%B2%C3%B3ks/example.py'
     );

--- a/packages/jupyterlab-lsp/src/utils.ts
+++ b/packages/jupyterlab-lsp/src/utils.ts
@@ -12,28 +12,6 @@ export async function sleep(timeout: number) {
   });
 }
 
-// TODO: there is a JL native version of this which uses adaptive rate, maybe use instead?
-export function until_ready(
-  is_ready: any,
-  max_retrials: number = 35,
-  interval = 50,
-  interval_modifier = (i: number) => i
-) {
-  return new Promise(async (resolve, reject) => {
-    let i = 0;
-    while (is_ready() !== true) {
-      i += 1;
-      if (max_retrials !== -1 && i > max_retrials) {
-        reject('Too many retrials');
-        break;
-      }
-      interval = interval_modifier(interval);
-      await sleep(interval);
-    }
-    resolve(is_ready);
-  });
-}
-
 export type ModifierKey =
   | 'Shift'
   | 'Alt'
@@ -91,28 +69,28 @@ export function getModifierState(
 
 export class DefaultMap<K, V> extends Map<K, V> {
   constructor(
-    private default_factory: (...args: any[]) => V,
+    private defaultFactory: (...args: any[]) => V,
     entries?: ReadonlyArray<readonly [K, V]> | null
   ) {
     super(entries);
   }
 
   get(k: K): V {
-    return this.get_or_create(k);
+    return this.getOrCreate(k);
   }
 
-  get_or_create(k: K, ...args: any[]): V {
+  getOrCreate(k: K, ...args: any[]): V {
     if (this.has(k)) {
       return super.get(k)!;
     } else {
-      let v = this.default_factory(k, ...args);
+      let v = this.defaultFactory(k, ...args);
       this.set(k, v);
       return v;
     }
   }
 }
 
-export function server_root_uri() {
+function serverRootUri() {
   return PageConfig.getOption('rootUri');
 }
 
@@ -122,11 +100,11 @@ export function server_root_uri() {
  * - uri encoding
  * TODO: probably use vscode-uri
  */
-export function uris_equal(a: string, b: string) {
-  const win_paths = is_win_path(a) && is_win_path(b);
-  if (win_paths) {
-    a = normalize_win_path(a);
-    b = normalize_win_path(b);
+export function urisEqual(a: string, b: string) {
+  const winPaths = isWinPath(a) && isWinPath(b);
+  if (winPaths) {
+    a = normalizeWinPath(a);
+    b = normalizeWinPath(b);
   }
   return a === b || decodeURI(a) === decodeURI(b);
 }
@@ -134,14 +112,14 @@ export function uris_equal(a: string, b: string) {
 /**
  * grossly detect whether a URI represents a file on a windows drive
  */
-export function is_win_path(uri: string) {
+export function isWinPath(uri: string) {
   return uri.match(RE_PATH_ANCHOR);
 }
 
 /**
  * lowercase the drive component of a URI
  */
-export function normalize_win_path(uri: string) {
+export function normalizeWinPath(uri: string) {
   // Pyright encodes colon on Windows, see:
   // https://github.com/jupyter-lsp/jupyterlab-lsp/pull/587#issuecomment-844225253
   return uri.replace(RE_PATH_ANCHOR, it =>
@@ -149,8 +127,8 @@ export function normalize_win_path(uri: string) {
   );
 }
 
-export function uri_to_contents_path(child: string, parent?: string) {
-  parent = parent || server_root_uri();
+export function uriToContentsPath(child: string, parent?: string) {
+  parent = parent || serverRootUri();
   if (parent == null) {
     return null;
   }

--- a/packages/jupyterlab-lsp/src/virtual/console.ts
+++ b/packages/jupyterlab-lsp/src/virtual/console.ts
@@ -14,7 +14,7 @@ interface ILogConsoleImplementation extends ILogConsoleCore {
   bindThis(): any;
 }
 
-function to_string(args: any[]): string {
+function toString(args: any[]): string {
   return args
     .map(arg => {
       let textual: string;
@@ -61,16 +61,16 @@ class FloatingConsole implements ILogConsoleImplementation {
   }
 
   debug(...args: any[]) {
-    this.append(to_string(args), 'debug');
+    this.append(toString(args), 'debug');
   }
   log(...args: any[]) {
-    this.append(to_string(args), 'log');
+    this.append(toString(args), 'log');
   }
   warn(...args: any[]) {
-    this.append(to_string(args), 'warn');
+    this.append(toString(args), 'warn');
   }
   error(...args: any[]) {
-    this.append(to_string(args), 'error');
+    this.append(toString(args), 'error');
   }
 }
 
@@ -106,8 +106,8 @@ class ConsoleWrapper implements ILSPLogConsole {
     this.breadcrumbs = scope;
     this._scope = this.breadcrumbs.join('.') + ':';
     this.singleton = singleton;
-    this.singleton.changed.connect(this._rebind_functions.bind(this));
-    this._rebind_functions();
+    this.singleton.changed.connect(this._rebindFunctions.bind(this));
+    this._rebindFunctions();
   }
 
   /**
@@ -115,22 +115,22 @@ class ConsoleWrapper implements ILSPLogConsole {
    * location (file:line) of the actual call rather than of this wrapper
    * when using with the browser implementation.
    */
-  _rebind_functions() {
-    const no_op = () => {
+  _rebindFunctions() {
+    const noOp = () => {
       // do nothing
     };
-    const bind_arg = this.implementation.bindThis();
+    const bindArg = this.implementation.bindThis();
 
     if (this.verbosity === 'debug') {
-      this.debug = this.implementation.debug.bind(bind_arg, this._scope);
+      this.debug = this.implementation.debug.bind(bindArg, this._scope);
     } else {
-      this.debug = no_op;
+      this.debug = noOp;
     }
 
     if (this.verbosity === 'debug' || this.verbosity === 'log') {
-      this.log = this.implementation.log.bind(bind_arg, this._scope);
+      this.log = this.implementation.log.bind(bindArg, this._scope);
     } else {
-      this.log = no_op;
+      this.log = noOp;
     }
 
     if (
@@ -138,12 +138,12 @@ class ConsoleWrapper implements ILSPLogConsole {
       this.verbosity === 'log' ||
       this.verbosity === 'warn'
     ) {
-      this.warn = this.implementation.warn.bind(bind_arg, this._scope);
+      this.warn = this.implementation.warn.bind(bindArg, this._scope);
     } else {
-      this.warn = no_op;
+      this.warn = noOp;
     }
 
-    this.error = this.implementation.error.bind(bind_arg, this._scope);
+    this.error = this.implementation.error.bind(bindArg, this._scope);
   }
 
   get verbosity() {
@@ -177,13 +177,13 @@ class ConsoleSingleton {
   public implementation: ILogConsoleImplementation;
   public changed: Signal<ConsoleSingleton, void>;
 
-  constructor(setting_registry: ISettingRegistry) {
+  constructor(settingRegistry: ISettingRegistry) {
     // until loaded log everything, to browser console
     this.verbosity = 'debug';
     this.implementation = new BrowserConsole();
     this.changed = new Signal(this);
 
-    setting_registry
+    settingRegistry
       .load(PLUGIN_ID + ':plugin')
       .then(settings => {
         this.updateSettings(settings);
@@ -223,8 +223,8 @@ class ConsoleSingleton {
 export const LOG_CONSOLE: JupyterFrontEndPlugin<ILSPLogConsole> = {
   id: PLUGIN_ID + ':ILSPLogConsole',
   requires: [ISettingRegistry],
-  activate: (app, setting_registry: ISettingRegistry) => {
-    const singleton = new ConsoleSingleton(setting_registry);
+  activate: (app, settingRegistry: ISettingRegistry) => {
+    const singleton = new ConsoleSingleton(settingRegistry);
     return new ConsoleWrapper(['LSP'], singleton);
   },
   provides: ILSPLogConsole,

--- a/packages/jupyterlab-lsp/src/virtual/document.spec.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.spec.ts
@@ -18,36 +18,36 @@ print("plotted")
 `;
 
 describe('isWithinRange', () => {
-  let line_range: CodeEditor.IRange = {
+  let lineRange: CodeEditor.IRange = {
     start: { line: 1, column: 0 },
     end: { line: 1, column: 10 }
   };
-  let long_range: CodeEditor.IRange = {
+  let longRange: CodeEditor.IRange = {
     start: { line: 0, column: 3 },
     end: { line: 1, column: 0 }
   };
   it('recognizes positions within range in a single-line case', () => {
-    expect(isWithinRange({ line: 1, column: 0 }, line_range)).toEqual(true);
-    expect(isWithinRange({ line: 1, column: 5 }, line_range)).toEqual(true);
-    expect(isWithinRange({ line: 1, column: 10 }, line_range)).toEqual(true);
+    expect(isWithinRange({ line: 1, column: 0 }, lineRange)).toEqual(true);
+    expect(isWithinRange({ line: 1, column: 5 }, lineRange)).toEqual(true);
+    expect(isWithinRange({ line: 1, column: 10 }, lineRange)).toEqual(true);
   });
 
   it('recognizes positions outside of range in a single-line case', () => {
-    expect(isWithinRange({ line: 0, column: 0 }, line_range)).toEqual(false);
-    expect(isWithinRange({ line: 2, column: 0 }, line_range)).toEqual(false);
+    expect(isWithinRange({ line: 0, column: 0 }, lineRange)).toEqual(false);
+    expect(isWithinRange({ line: 2, column: 0 }, lineRange)).toEqual(false);
   });
 
   it('recognizes positions within range in multi-line case', () => {
-    expect(isWithinRange({ line: 0, column: 3 }, long_range)).toEqual(true);
-    expect(isWithinRange({ line: 0, column: 5 }, long_range)).toEqual(true);
-    expect(isWithinRange({ line: 1, column: 0 }, long_range)).toEqual(true);
+    expect(isWithinRange({ line: 0, column: 3 }, longRange)).toEqual(true);
+    expect(isWithinRange({ line: 0, column: 5 }, longRange)).toEqual(true);
+    expect(isWithinRange({ line: 1, column: 0 }, longRange)).toEqual(true);
   });
 
   it('recognizes positions outside of range in multi-line case', () => {
-    expect(isWithinRange({ line: 0, column: 0 }, long_range)).toEqual(false);
-    expect(isWithinRange({ line: 0, column: 1 }, long_range)).toEqual(false);
-    expect(isWithinRange({ line: 0, column: 2 }, long_range)).toEqual(false);
-    expect(isWithinRange({ line: 1, column: 1 }, long_range)).toEqual(false);
+    expect(isWithinRange({ line: 0, column: 0 }, longRange)).toEqual(false);
+    expect(isWithinRange({ line: 0, column: 1 }, longRange)).toEqual(false);
+    expect(isWithinRange({ line: 0, column: 2 }, longRange)).toEqual(false);
+    expect(isWithinRange({ line: 1, column: 1 }, longRange)).toEqual(false);
   });
 });
 
@@ -66,39 +66,39 @@ describe('VirtualDocument', () => {
   });
 
   let initDocumentWithPythonAndR = () => {
-    let ceEditor_for_cell_1 = {} as Document.IEditor;
-    let ceEditor_for_cell_2 = {} as Document.IEditor;
-    let ceEditor_for_cell_3 = {} as Document.IEditor;
-    let ceEditor_for_cell_4 = {} as Document.IEditor;
+    let ceEditorForCell1 = {} as Document.IEditor;
+    let ceEditorForCell2 = {} as Document.IEditor;
+    let ceEditorForCell3 = {} as Document.IEditor;
+    let ceEditorForCell4 = {} as Document.IEditor;
     // first block
     document.appendCodeBlock({
       value: 'test line in Python 1\n%R 1st test line in R line magic 1',
-      ceEditor: ceEditor_for_cell_1,
+      ceEditor: ceEditorForCell1,
       type: 'code'
     });
     // second block
     document.appendCodeBlock({
       value: 'test line in Python 2\n%R 1st test line in R line magic 2',
-      ceEditor: ceEditor_for_cell_2,
+      ceEditor: ceEditorForCell2,
       type: 'code'
     });
     // third block
     document.appendCodeBlock({
       value:
         'test line in Python 3\n%R -i imported_variable 1st test line in R line magic 3',
-      ceEditor: ceEditor_for_cell_2,
+      ceEditor: ceEditorForCell2,
       type: 'code'
     });
     // fourth block
     document.appendCodeBlock({
       value: '%%R\n1st test line in R cell magic 1',
-      ceEditor: ceEditor_for_cell_3,
+      ceEditor: ceEditorForCell3,
       type: 'code'
     });
     // fifth block
     document.appendCodeBlock({
       value: '%%R -i imported_variable\n1st test line in R cell magic 2',
-      ceEditor: ceEditor_for_cell_4,
+      ceEditor: ceEditorForCell4,
       type: 'code'
     });
   };
@@ -118,11 +118,11 @@ describe('VirtualDocument', () => {
       expect(cellCodeKept).toEqual(R_LINE_MAGICS);
       expect(foreignDocumentsMap.size).toEqual(2);
 
-      let { virtualDocument: r_document } = foreignDocumentsMap.get(
+      let { virtualDocument: rDocument } = foreignDocumentsMap.get(
         foreignDocumentsMap.keys().next().value
       )!;
-      expect(r_document.language).toEqual('r');
-      expect(r_document.value).toEqual('df = data.frame()\n\n\nggplot(df)\n');
+      expect(rDocument.language).toEqual('r');
+      expect(rDocument.value).toEqual('df = data.frame()\n\n\nggplot(df)\n');
     });
   });
 
@@ -130,20 +130,20 @@ describe('VirtualDocument', () => {
     it('transforms positions for the top level document', () => {
       initDocumentWithPythonAndR();
       // The first (Python) line in the first block
-      let editor_position = document.transformVirtualToEditor({
+      let editorPosition = document.transformVirtualToEditor({
         line: 0,
         ch: 0
       } as IVirtualPosition)!;
-      expect(editor_position.line).toEqual(0);
-      expect(editor_position.ch).toEqual(0);
+      expect(editorPosition.line).toEqual(0);
+      expect(editorPosition.ch).toEqual(0);
 
       // The first (Python) line in the second block
-      editor_position = document.transformVirtualToEditor({
+      editorPosition = document.transformVirtualToEditor({
         line: 4,
         ch: 0
       } as IVirtualPosition)!;
-      expect(editor_position.line).toEqual(0);
-      expect(editor_position.ch).toEqual(0);
+      expect(editorPosition.line).toEqual(0);
+      expect(editorPosition.ch).toEqual(0);
     });
 
     it('transforms positions for the nested foreign documents', () => {
@@ -165,57 +165,57 @@ describe('VirtualDocument', () => {
 
       // The first R line (in source); second in the first block;
       // targeting "s" in "1st", "1st" in "1st test line in R line magic" (first virtual line == line 0)
-      let virtual_r_1_1 = {
+      let virtualR1s1line = {
         line: 0,
         ch: 1
       } as IVirtualPosition;
 
       // For future reference, the code below would be wrong:
-      // let source_position = foreignDocument.transform_virtual_to_source(virtual_r_1_1);
+      // let source_position = foreignDocument.transform_virtual_to_source(virtualR1s1line);
       // expect(source_position.line).toEqual(1);
       // expect(source_position.ch).toEqual(4);
       // because it checks R source position, rather than checking root source positions.
 
-      let editor_position =
-        foreignDocument.transformVirtualToEditor(virtual_r_1_1)!;
-      expect(editor_position.line).toEqual(1);
-      expect(editor_position.ch).toEqual(4);
+      let editorPosition =
+        foreignDocument.transformVirtualToEditor(virtualR1s1line)!;
+      expect(editorPosition.line).toEqual(1);
+      expect(editorPosition.ch).toEqual(4);
 
       // The second R line (in source), second in the second block
       // targeting 1 in "1st test line in R line magic 2" (4th virtual line == line 3)
-      editor_position = foreignDocument.transformVirtualToEditor({
+      editorPosition = foreignDocument.transformVirtualToEditor({
         line: 3,
         ch: 0
       } as IVirtualPosition)!;
       // 0th editor line is 'test line in Python 2\n'
-      expect(editor_position.line).toEqual(1);
+      expect(editorPosition.line).toEqual(1);
       // 1st editor lines is '%R 1st test line in R line magic 2'
       //                      0123 - 3rd character
-      expect(editor_position.ch).toEqual(3);
+      expect(editorPosition.ch).toEqual(3);
 
       // The third R line (in source), second in the third block;
       // targeting "s" in "1st" in "1st test line in R line magic 3" (7th virtual line == line 6)
-      editor_position = foreignDocument.transformVirtualToEditor({
+      editorPosition = foreignDocument.transformVirtualToEditor({
         line: 6,
         ch: 36
       } as IVirtualPosition)!;
       // 0th editor line is 'test line in Python 3\n'
-      expect(editor_position.line).toEqual(1);
+      expect(editorPosition.line).toEqual(1);
       // 1st editor line is '%R -i imported_variable 1st test line in R line magic 3'
       //                     01234567890123456789012345 - 25th character
-      expect(editor_position.ch).toEqual(25);
+      expect(editorPosition.ch).toEqual(25);
 
       // The fifth R line (in source), second in the fifth block;
       // targeting "s" in "1st" in "1st test line in R cell magic 2" (13th virtual lines == line 12)
-      editor_position = foreignDocument.transformVirtualToEditor({
+      editorPosition = foreignDocument.transformVirtualToEditor({
         line: 12,
         ch: 36
       } as IVirtualPosition)!;
       // 0th editor line is '%%R -i imported_variable\n'
-      expect(editor_position.line).toEqual(1);
+      expect(editorPosition.line).toEqual(1);
       // 1st editor line is '1st test line in R cell magic 2'
       //                     01
-      expect(editor_position.ch).toEqual(1);
+      expect(editorPosition.ch).toEqual(1);
     });
   });
 });

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -36,15 +36,14 @@ export class VirtualDocument extends VirtualDocumentBase {
   }
 
   // TODO: this could be moved out
-  decodeCodeBlock(raw_code: string): string {
+  decodeCodeBlock(rawCode: string): string {
     // TODO: add back previously extracted foreign code
-    const cellOverride =
-      this.cellMagicsOverrides.reverse.override_for(raw_code);
+    const cellOverride = this.cellMagicsOverrides.reverse.overrideFor(rawCode);
     if (cellOverride != null) {
       return cellOverride;
     } else {
-      let lines = this.lineMagicsOverrides.reverse_replace_all(
-        raw_code.split('\n')
+      let lines = this.lineMagicsOverrides.reverseReplaceAll(
+        rawCode.split('\n')
       );
       return lines.join('\n');
     }
@@ -67,13 +66,13 @@ export class VirtualDocument extends VirtualDocumentBase {
     const cellCode = cellCodeKept;
 
     // cell magics are replaced if requested and matched
-    const cellOverride = this.cellMagicsOverrides.override_for(cellCode);
+    const cellOverride = this.cellMagicsOverrides.overrideFor(cellCode);
     if (cellOverride != null) {
       lines = cellOverride.split('\n');
-      skipInspect = lines.map(l => [this.idPath]);
+      skipInspect = lines.map(_line => [this.idPath]);
     } else {
       // otherwise, we replace line magics - if any
-      let result = this.lineMagicsOverrides.replace_all(cellCode.split('\n'));
+      let result = this.lineMagicsOverrides.replaceAll(cellCode.split('\n'));
       lines = result.lines;
       skipInspect = result.skipInspect.map(skip => (skip ? [this.idPath] : []));
     }

--- a/packages/theme-material/src/index.ts
+++ b/packages/theme-material/src/index.ts
@@ -6,37 +6,37 @@ import {
 } from '@jupyter-lsp/completion-theme';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 
-import alpha_t_over_code from '../style/icons/alpha-t-and-code.svg';
+import alphaTOverCode from '../style/icons/alpha-t-and-code.svg';
 import alphabetical from '../style/icons/alphabetical.svg';
 import beaker from '../style/icons/beaker-outline.svg';
 import snippet from '../style/icons/border-none-variant.svg';
 import field from '../style/icons/checkbox-blank-circle-outline.svg';
 import variable from '../style/icons/checkbox-blank-outline.svg';
 import file from '../style/icons/file-outline.svg';
-import file_replace from '../style/icons/file-replace-outline.svg';
+import fileReplace from '../style/icons/file-replace-outline.svg';
 import structure from '../style/icons/file-tree.svg';
 import lightning from '../style/icons/flash-outline.svg';
 import folder from '../style/icons/folder-outline.svg';
-import list_numbered from '../style/icons/format-list-numbered-rtl.svg';
-import func_variant from '../style/icons/function-variant.svg';
+import listNumbered from '../style/icons/format-list-numbered-rtl.svg';
+import funcVariant from '../style/icons/function-variant.svg';
 import func from '../style/icons/function.svg';
-import hammer_wrench from '../style/icons/hammer-wrench.svg';
+import hammerWrench from '../style/icons/hammer-wrench.svg';
 import key from '../style/icons/key.svg';
 import number from '../style/icons/numeric.svg';
 import module from '../style/icons/package-variant-closed.svg';
 import palette from '../style/icons/palette-outline.svg';
-import plus_minus from '../style/icons/plus-minus-variant.svg';
+import plusMinus from '../style/icons/plus-minus-variant.svg';
 import shield from '../style/icons/shield-outline.svg';
 import sitemap from '../style/icons/sitemap.svg';
 import value from '../style/icons/text.svg';
 import connection from '../style/icons/transit-connection-horizontal.svg';
 import wrench from '../style/icons/wrench.svg';
 
-const default_set: ICompletionIconSet = {
+const defaultSet: ICompletionIconSet = {
   Text: alphabetical,
   Method: func,
-  Function: func_variant,
-  Constructor: hammer_wrench,
+  Function: funcVariant,
+  Constructor: hammerWrench,
   Field: field,
   Variable: variable,
   Class: structure,
@@ -45,19 +45,19 @@ const default_set: ICompletionIconSet = {
   Property: wrench,
   Unit: beaker,
   Value: value,
-  Enum: list_numbered,
+  Enum: listNumbered,
   Keyword: key,
   Snippet: snippet,
   Color: palette,
   File: file,
-  Reference: file_replace,
+  Reference: fileReplace,
   Folder: folder,
   EnumMember: number,
   Constant: shield,
   Struct: sitemap,
   Event: lightning,
-  Operator: plus_minus,
-  TypeParameter: alpha_t_over_code
+  Operator: plusMinus,
+  TypeParameter: alphaTOverCode
 };
 
 const completionTheme: ICompletionTheme = {
@@ -70,7 +70,7 @@ const completionTheme: ICompletionTheme = {
       licensor: 'Austin Andrews and Google',
       link: 'https://github.com/Templarian/MaterialDesign/blob/master/LICENSE'
     },
-    light: default_set
+    light: defaultSet
   }
 };
 
@@ -81,7 +81,7 @@ export const plugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-lsp/theme-material',
   requires: [ILSPCompletionThemeManager],
   activate: (app, completionThemeManager: ILSPCompletionThemeManager) => {
-    completionThemeManager.register_theme(completionTheme);
+    completionThemeManager.registerTheme(completionTheme);
   },
   autoStart: true
 };

--- a/packages/theme-vscode/src/index.ts
+++ b/packages/theme-vscode/src/index.ts
@@ -6,111 +6,111 @@ import {
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 
 import '../style/completer.css';
-import dark_file from '../style/icons/dark/file.svg';
-import dark_folder from '../style/icons/dark/folder.svg';
-import dark_json from '../style/icons/dark/json.svg';
-import dark_value from '../style/icons/dark/note.svg';
-import dark_references from '../style/icons/dark/references.svg';
-import dark_symbol_class from '../style/icons/dark/symbol-class.svg';
-import dark_symbol_color from '../style/icons/dark/symbol-color.svg';
-import dark_symbol_constant from '../style/icons/dark/symbol-constant.svg';
-import dark_symbol_enumerator_member from '../style/icons/dark/symbol-enumerator-member.svg';
-import dark_symbol_enumerator from '../style/icons/dark/symbol-enumerator.svg';
-import dark_symbol_event from '../style/icons/dark/symbol-event.svg';
-import dark_symbol_field from '../style/icons/dark/symbol-field.svg';
-import dark_symbol_interface from '../style/icons/dark/symbol-interface.svg';
-import dark_symbol_keyword from '../style/icons/dark/symbol-keyword.svg';
-import dark_symbol_method from '../style/icons/dark/symbol-method.svg';
-import dark_symbol_operator from '../style/icons/dark/symbol-operator.svg';
-import dark_symbol_parameter from '../style/icons/dark/symbol-parameter.svg';
-import dark_symbol_property from '../style/icons/dark/symbol-property.svg';
-import dark_symbol_ruler from '../style/icons/dark/symbol-ruler.svg';
-import dark_symbol_snippet from '../style/icons/dark/symbol-snippet.svg';
-import dark_symbol_string from '../style/icons/dark/symbol-string.svg';
-import dark_symbol_structure from '../style/icons/dark/symbol-structure.svg';
-import dark_symbol_variable from '../style/icons/dark/symbol-variable.svg';
+import darkFile from '../style/icons/dark/file.svg';
+import darkFolder from '../style/icons/dark/folder.svg';
+import darkJson from '../style/icons/dark/json.svg';
+import darkValue from '../style/icons/dark/note.svg';
+import darkReferences from '../style/icons/dark/references.svg';
+import darkSymbolClass from '../style/icons/dark/symbol-class.svg';
+import darkSymbolColor from '../style/icons/dark/symbol-color.svg';
+import darkSymbolConstant from '../style/icons/dark/symbol-constant.svg';
+import darkSymbolEnumeratorMember from '../style/icons/dark/symbol-enumerator-member.svg';
+import darkSymbolEnumerator from '../style/icons/dark/symbol-enumerator.svg';
+import darkSymbolEvent from '../style/icons/dark/symbol-event.svg';
+import darkSymbolField from '../style/icons/dark/symbol-field.svg';
+import darkSymbolInterface from '../style/icons/dark/symbol-interface.svg';
+import darkSymbolKeyword from '../style/icons/dark/symbol-keyword.svg';
+import darkSymbolMethod from '../style/icons/dark/symbol-method.svg';
+import darkSymbolOperator from '../style/icons/dark/symbol-operator.svg';
+import darkSymbolParameter from '../style/icons/dark/symbol-parameter.svg';
+import darkSymbolProperty from '../style/icons/dark/symbol-property.svg';
+import darkSymbolRuler from '../style/icons/dark/symbol-ruler.svg';
+import darkSymbolSnippet from '../style/icons/dark/symbol-snippet.svg';
+import darkSymbolString from '../style/icons/dark/symbol-string.svg';
+import darkSymbolStructure from '../style/icons/dark/symbol-structure.svg';
+import darkSymbolVariable from '../style/icons/dark/symbol-variable.svg';
 import file from '../style/icons/light/file.svg';
 import folder from '../style/icons/light/folder.svg';
 import json from '../style/icons/light/json.svg';
 import value from '../style/icons/light/note.svg';
 import references from '../style/icons/light/references.svg';
-import symbol_class from '../style/icons/light/symbol-class.svg';
-import symbol_color from '../style/icons/light/symbol-color.svg';
-import symbol_constant from '../style/icons/light/symbol-constant.svg';
-import symbol_enumerator_member from '../style/icons/light/symbol-enumerator-member.svg';
-import symbol_enumerator from '../style/icons/light/symbol-enumerator.svg';
-import symbol_event from '../style/icons/light/symbol-event.svg';
-import symbol_field from '../style/icons/light/symbol-field.svg';
-import symbol_interface from '../style/icons/light/symbol-interface.svg';
-import symbol_keyword from '../style/icons/light/symbol-keyword.svg';
-import symbol_method from '../style/icons/light/symbol-method.svg';
-import symbol_operator from '../style/icons/light/symbol-operator.svg';
-import symbol_parameter from '../style/icons/light/symbol-parameter.svg';
-import symbol_property from '../style/icons/light/symbol-property.svg';
-import symbol_ruler from '../style/icons/light/symbol-ruler.svg';
-import symbol_snippet from '../style/icons/light/symbol-snippet.svg';
-import symbol_string from '../style/icons/light/symbol-string.svg';
-import symbol_structure from '../style/icons/light/symbol-structure.svg';
-import symbol_variable from '../style/icons/light/symbol-variable.svg';
+import symbolClass from '../style/icons/light/symbol-class.svg';
+import symbolColor from '../style/icons/light/symbol-color.svg';
+import symbolConstant from '../style/icons/light/symbol-constant.svg';
+import symbolEnumeratorMember from '../style/icons/light/symbol-enumerator-member.svg';
+import symbolEnumerator from '../style/icons/light/symbol-enumerator.svg';
+import symbolEvent from '../style/icons/light/symbol-event.svg';
+import symbolField from '../style/icons/light/symbol-field.svg';
+import symbolInterface from '../style/icons/light/symbol-interface.svg';
+import symbolKeyword from '../style/icons/light/symbol-keyword.svg';
+import symbolMethod from '../style/icons/light/symbol-method.svg';
+import symbolOperator from '../style/icons/light/symbol-operator.svg';
+import symbolParameter from '../style/icons/light/symbol-parameter.svg';
+import symbolProperty from '../style/icons/light/symbol-property.svg';
+import symbolRuler from '../style/icons/light/symbol-ruler.svg';
+import symbolSnippet from '../style/icons/light/symbol-snippet.svg';
+import symbolString from '../style/icons/light/symbol-string.svg';
+import symbolStructure from '../style/icons/light/symbol-structure.svg';
+import symbolVariable from '../style/icons/light/symbol-variable.svg';
 
 /**
  * Dark theme variants
  */
 
-const light_set: ICompletionIconSet = {
-  Text: symbol_string,
-  Method: symbol_method,
-  Function: symbol_method,
-  Constructor: symbol_method,
-  Field: symbol_field,
-  Variable: symbol_variable,
-  Class: symbol_class,
-  Interface: symbol_interface,
+const lightSet: ICompletionIconSet = {
+  Text: symbolString,
+  Method: symbolMethod,
+  Function: symbolMethod,
+  Constructor: symbolMethod,
+  Field: symbolField,
+  Variable: symbolVariable,
+  Class: symbolClass,
+  Interface: symbolInterface,
   Module: json,
-  Property: symbol_property,
-  Unit: symbol_ruler,
+  Property: symbolProperty,
+  Unit: symbolRuler,
   Value: value,
-  Enum: symbol_enumerator,
-  Keyword: symbol_keyword,
-  Snippet: symbol_snippet,
-  Color: symbol_color,
+  Enum: symbolEnumerator,
+  Keyword: symbolKeyword,
+  Snippet: symbolSnippet,
+  Color: symbolColor,
   File: file,
   Reference: references,
   Folder: folder,
-  EnumMember: symbol_enumerator_member,
-  Constant: symbol_constant,
-  Struct: symbol_structure,
-  Event: symbol_event,
-  Operator: symbol_operator,
-  TypeParameter: symbol_parameter
+  EnumMember: symbolEnumeratorMember,
+  Constant: symbolConstant,
+  Struct: symbolStructure,
+  Event: symbolEvent,
+  Operator: symbolOperator,
+  TypeParameter: symbolParameter
 };
 
-const dark_set: ICompletionIconSet = {
-  Text: dark_symbol_string,
-  Method: dark_symbol_method,
-  Function: dark_symbol_method,
-  Constructor: dark_symbol_method,
-  Field: dark_symbol_field,
-  Variable: dark_symbol_variable,
-  Class: dark_symbol_class,
-  Interface: dark_symbol_interface,
-  Module: dark_json,
-  Property: dark_symbol_property,
-  Unit: dark_symbol_ruler,
-  Value: dark_value,
-  Enum: dark_symbol_enumerator,
-  Keyword: dark_symbol_keyword,
-  Snippet: dark_symbol_snippet,
-  Color: dark_symbol_color,
-  File: dark_file,
-  Reference: dark_references,
-  Folder: dark_folder,
-  EnumMember: dark_symbol_enumerator_member,
-  Constant: dark_symbol_constant,
-  Struct: dark_symbol_structure,
-  Event: dark_symbol_event,
-  Operator: dark_symbol_operator,
-  TypeParameter: dark_symbol_parameter
+const darkSet: ICompletionIconSet = {
+  Text: darkSymbolString,
+  Method: darkSymbolMethod,
+  Function: darkSymbolMethod,
+  Constructor: darkSymbolMethod,
+  Field: darkSymbolField,
+  Variable: darkSymbolVariable,
+  Class: darkSymbolClass,
+  Interface: darkSymbolInterface,
+  Module: darkJson,
+  Property: darkSymbolProperty,
+  Unit: darkSymbolRuler,
+  Value: darkValue,
+  Enum: darkSymbolEnumerator,
+  Keyword: darkSymbolKeyword,
+  Snippet: darkSymbolSnippet,
+  Color: darkSymbolColor,
+  File: darkFile,
+  Reference: darkReferences,
+  Folder: darkFolder,
+  EnumMember: darkSymbolEnumeratorMember,
+  Constant: darkSymbolConstant,
+  Struct: darkSymbolStructure,
+  Event: darkSymbolEvent,
+  Operator: darkSymbolOperator,
+  TypeParameter: darkSymbolParameter
 };
 
 const completionTheme: ICompletionTheme = {
@@ -123,8 +123,8 @@ const completionTheme: ICompletionTheme = {
       licensor: 'Microsoft',
       link: 'https://github.com/microsoft/vscode-icons/blob/master/LICENSE'
     },
-    light: light_set,
-    dark: dark_set
+    light: lightSet,
+    dark: darkSet
   }
 };
 
@@ -132,7 +132,7 @@ export const plugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-lsp/theme-vscode',
   requires: [ILSPCompletionThemeManager],
   activate: (app, completionThemeManager: ILSPCompletionThemeManager) => {
-    completionThemeManager.register_theme(completionTheme);
+    completionThemeManager.registerTheme(completionTheme);
   },
   autoStart: true
 };


### PR DESCRIPTION
## References

Closes #47

## Code changes

- enables `camelCase` rule
- enables `no-empty-interface`

## User-facing changes

None

## Backwards-incompatible changes

Public API is now camelCase typed