### PR TITLE
Automatically show and dismiss notifications

### DIFF
--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -249,7 +249,10 @@ class DiagnosticsPanel {
           .writeText(message)
           .then(() => {
             Notification.info(
-              this.trans.__('Successfully copied "%1" to clipboard', message)
+              this.trans.__('Successfully copied "%1" to clipboard', message),
+              {
+                autoClose: 3 * 1000
+              }
             );
           })
           .catch(() => {

--- a/packages/jupyterlab-lsp/src/features/jump_to.ts
+++ b/packages/jupyterlab-lsp/src/features/jump_to.ts
@@ -353,10 +353,9 @@ export class NavigationFeature extends Feature {
     const jumper = this.getJumper(adapter);
 
     if (!targetInfo) {
-      const notificationID = Notification.info(
-        this._trans.__('No jump targets found')
-      );
-      setTimeout(() => Notification.dismiss(notificationID), 2 * 1000);
+      Notification.info(this._trans.__('No jump targets found'), {
+        autoClose: 3 * 1000
+      });
       return JumpResult.NoTargetsFound;
     }
 
@@ -542,12 +541,9 @@ export const JUMP_PLUGIN: JupyterFrontEndPlugin<void> = {
         const { connection, virtualPosition, document, adapter } = context;
 
         if (!connection) {
-          const notificationId = Notification.info(
-            trans.__('Connection not found for jump')
-          );
-          setTimeout(() => {
-            Notification.dismiss(notificationId);
-          }, 2 * 1000);
+          Notification.warning(trans.__('Connection not found for jump'), {
+            autoClose: 4 * 1000
+          });
           return;
         }
 
@@ -588,12 +584,9 @@ export const JUMP_PLUGIN: JupyterFrontEndPlugin<void> = {
         const { connection, virtualPosition, document, adapter } = context;
 
         if (!connection) {
-          const notificationId = Notification.info(
-            trans.__('Connection not found for jump')
-          );
-          setTimeout(() => {
-            Notification.dismiss(notificationId);
-          }, 2 * 1000);
+          Notification.warning(trans.__('Connection not found for jump'), {
+            autoClose: 5 * 1000
+          });
           return;
         }
 

--- a/packages/jupyterlab-lsp/src/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/features/rename.ts
@@ -116,7 +116,9 @@ export class RenameFeature extends Feature {
         severity = 'error';
       }
 
-      Notification.emit(status, severity);
+      Notification.emit(status, severity, {
+        autoClose: (severity === 'error' ? 5 : 3) * 1000
+      });
     } catch (error) {
       this.console.warn(error);
     }
@@ -267,9 +269,11 @@ export const RENAME_PLUGIN: JupyterFrontEndPlugin<void> = {
           }
 
           if (!status) {
-            Notification.error(trans.__(`Rename failed: %1`, error));
+            Notification.error(trans.__(`Rename failed: %1`, error), {
+              autoClose: 5 * 1000
+            });
           } else {
-            Notification.info(status);
+            Notification.warning(status, { autoClose: 3 * 1000 });
           }
         };
 
@@ -287,7 +291,8 @@ export const RENAME_PLUGIN: JupyterFrontEndPlugin<void> = {
             return;
           }
           Notification.info(
-            trans.__('Renaming %1 to %2...', oldValue, newValue)
+            trans.__('Renaming %1 to %2…', oldValue, newValue),
+            { autoClose: 3 * 1000 }
           );
           const edit = await connection!.clientRequests[
             'textDocument/rename'


### PR DESCRIPTION
## References

Follow up to #949 - use transient notifications to avoid spamming the notification centre.

## Code changes

- adds `autoClose` option where needed replacing manual `Notificaiton.dismiss` calls

## User-facing changes

| Before | After |
|---|---|
| ![before](https://github.com/jupyter-lsp/jupyterlab-lsp/assets/5832902/6e7942c7-b2b7-4462-b2e4-5cf9bde5197b) | ![after](https://github.com/jupyter-lsp/jupyterlab-lsp/assets/5832902/974b7ad3-bc70-4a03-996c-01b0572d0587) |


## Backwards-incompatible changes

None
