### PR TITLE
Fix jump to in notebooks, fix diagnostics and jump tests

### DIFF
--- a/atest/01_Editor.robot
+++ b/atest/01_Editor.robot
@@ -17,12 +17,12 @@ Bash
 
 CSS
     ${def} =    Set Variable
-    ...    xpath:(//span[contains(@class, 'cm-variable-2')][contains(text(), '--some-var')])[last()]
+    ...    xpath:(//span[contains(@class, 'cm-line')][contains(text(), '--some-var')])[last()]
     Editor Shows Features for Language    CSS    example.css    Diagnostics=Do not use empty rulesets
     ...    Jump to Definition=${def}    Rename=${def}
 
 Docker
-    ${def} =    Set Variable    xpath://span[contains(@class, 'cm-string')][contains(text(), 'PLANET')]
+    ${def} =    Set Variable    xpath://span[contains(@class, 'cm-line')][contains(text(), 'PLANET')]
     Wait Until Keyword Succeeds    3x    100ms    Editor Shows Features for Language    Docker    Dockerfile
     ...    Diagnostics=Instructions should be written in uppercase letters    Jump to Definition=${def}
     ...    Rename=${def}
@@ -36,20 +36,20 @@ JSON
     Editor Shows Features for Language    JSON    example.json    Diagnostics=Duplicate object key
 
 JSX
-    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'hello')])[last()]
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'hello')])[last()]
     Editor Shows Features for Language    JSX    example.jsx    Diagnostics=Expression expected
     ...    Jump to Definition=${def}    Rename=${def}
 # Julia
-#    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-builtin')][contains(text(), 'add_together')])[last()]
+#    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'add_together')])[last()]
 #    Editor Shows Features for Language    Julia    example.jl    Jump to Definition=${def}    Rename=${def}
 
 LaTeX
     [Tags]    language:latex
-    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-atom')][contains(text(), 'foo')])[last()]
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'foo')])[last()]
     Editor Shows Features for Language    LaTeX    example.tex    Jump to Definition=${def}    Rename=${def}
 
 Less
-    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable-2')][contains(text(), '@width')])[last()]
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-line')][contains(text(), '@width')])[last()]
     Editor Shows Features for Language    Less    example.less    Diagnostics=Do not use empty rulesets
     ...    Jump to Definition=${def}
 
@@ -57,7 +57,7 @@ Markdown
     Editor Shows Features for Language    Markdown    example.md    Diagnostics=`Color` is misspelt
 
 Python (pylsp)
-    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'fib')])[last()]
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'fib')])[last()]
     Editor Shows Features for Server
     ...    pylsp
     ...    Python
@@ -67,35 +67,35 @@ Python (pylsp)
     ...    Rename=${def}
 
 Python (pyright)
-    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'fib')])[last()]
+    ${def} =    Set Variable    xpath:(//div[contains(@class, 'cm-line')][contains(text(), 'fib')])[last()]
     Editor Shows Features for Server    pyright    Python    example.py    Diagnostics=is not defined (Pyright)
     ...    Jump to Definition=${def}
 
 R
-    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'fib')])[last()]
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'fib')])[last()]
     Editor Shows Features for Language    R    example.R    Diagnostics=Put spaces around all infix operators
     ...    Jump to Definition=${def}
 
 Robot Framework
     [Tags]    gh:332
     ${def} =    Set Variable
-    ...    xpath:(//span[contains(@class, 'cm-keyword')][contains(text(), 'Special Log')])[last()]
+    ...    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'Special Log')])[last()]
     Editor Shows Features for Language    Robot Framework    example.robot    Diagnostics=Undefined keyword
     ...    Jump to Definition=${def}
 
 SCSS
     ${def} =    Set Variable
-    ...    xpath:(//span[contains(@class, 'cm-variable-2')][contains(text(), 'primary-color')])[last()]
+    ...    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'primary-color')])[last()]
     Editor Shows Features for Language    SCSS    example.scss    Diagnostics=Do not use empty rulesets
     ...    Jump to Definition=${def}
 
 TSX
-    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-tag')][contains(text(), 'HelloWorld')])[last()]
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'HelloWorld')])[last()]
     Editor Shows Features for Language    TSX    example.tsx
     ...    Diagnostics='hello' is declared but its value is never read.    Jump to Definition=${def}    Rename=${def}
 
 TypeScript
-    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'inc')])[last()]
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-line')][contains(text(), 'inc')])[last()]
     Editor Shows Features for Language    TypeScript    example.ts    Diagnostics=The left-hand side of an arithmetic
     ...    Jump to Definition=${def}    Rename=${def}
 
@@ -137,7 +137,7 @@ Editor Shows Features for Language
 Editor Should Show Diagnostics
     [Arguments]    ${diagnostic}
     Set Tags    feature:diagnostics
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${diagnostic}"]    timeout=25s
+    Wait Until Page Contains Diagnostic    [title*="${diagnostic}"]    timeout=25s
     Capture Page Screenshot    01-diagnostics.png
     Open Diagnostics Panel
     Capture Page Screenshot    02-diagnostics.png

--- a/atest/03_Notebook.robot
+++ b/atest/03_Notebook.robot
@@ -9,8 +9,7 @@ Test Setup      Try to Close All Tabs
 Python
     [Setup]    Setup Notebook    Python    Python.ipynb
     ${diagnostic} =    Set Variable    W291 trailing whitespace (pycodestyle)
-    # TODO: no title for diagnostics; we can get the title with JS via `element.cmView.mark.spec.diagnostic.message` but this is not selectable
-    Wait Until Page Contains Element    css:.cm-lintRange[title="${diagnostic}"]    timeout=35s
+    Wait Until Page Contains Diagnostic    [title="${diagnostic}"]    timeout=35s
     Capture Page Screenshot    01-python.png
     [Teardown]    Clean Up After Working With File    Python.ipynb
 
@@ -40,11 +39,11 @@ Moving Cells Around
     [Setup]    Setup Notebook    Python    Python.ipynb
     ${diagnostic} =    Set Variable    undefined name 'test' (pyflakes)
     Enter Cell Editor    1
-    Lab Command    Move Cells Down
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title="${diagnostic}"]    timeout=35s
+    Lab Command    Move Cell Down
+    Wait Until Page Contains Diagnostic    [title="${diagnostic}"]    timeout=35s
     Enter Cell Editor    1
-    Lab Command    Move Cells Down
-    Wait Until Page Does Not Contain Element    css:.cm-lsp-diagnostic[title="${diagnostic}"]    timeout=35s
+    Lab Command    Move Cell Down
+    Wait Until Page Does Not Contain Diagnostic    [title="${diagnostic}"]    timeout=35s
     [Teardown]    Clean Up After Working With File    Python.ipynb
 
 Foreign Extractors
@@ -61,7 +60,7 @@ Foreign Extractors
     ...    `frob` is misspelt    # markdown
     ...    Command terminated with space    # latex
     FOR    ${diagnostic}    IN    @{diagnostics}
-        Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*\="${diagnostic}"]    timeout=35s
+        Wait Until Page Contains Diagnostic    [title*\="${diagnostic}"]    timeout=35s
     END
     Capture Page Screenshot    11-extracted.png
     [Teardown]    Clean Up After Working with File and Settings    ${file}

--- a/atest/04_Interface/DiagnosticsPanel.robot
+++ b/atest/04_Interface/DiagnosticsPanel.robot
@@ -26,7 +26,7 @@ Diagnostics Panel Works After Rename
     [Documentation]    Test for #141 bug (diagnostics were not cleared after rename)
     Rename Jupyter File    Panel.ipynb    PanelRenamed.ipynb
     Close Diagnostics Panel
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${DIAGNOSTIC}"]    timeout=20s
+    Wait Until Page Contains Diagnostic    [title*="${DIAGNOSTIC}"]    timeout=20s
     Capture Page Screenshot    00-panel-rename.png
     Open Diagnostics Panel
     Capture Page Screenshot    01-panel-rename.png
@@ -39,7 +39,7 @@ Diagnostics Panel Works After Kernel Restart
     Lab Command    Restart Kernel…
     Wait For Dialog
     Accept Default Dialog Option
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${DIAGNOSTIC}"]    timeout=20s
+    Wait Until Page Contains Diagnostic    [title*="${DIAGNOSTIC}"]    timeout=20s
     Open Diagnostics Panel
     Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    ${EXPECTED_COUNT}
 
@@ -135,7 +135,7 @@ Open Notebook And Panel
     [Arguments]    ${notebook}
     Setup Notebook    Python    ${notebook}
     Capture Page Screenshot    00-notebook-and-panel-openeing.png
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${DIAGNOSTIC}"]    timeout=20s
+    Wait Until Page Contains Diagnostic    [title*="${DIAGNOSTIC}"]    timeout=20s
     Open Diagnostics Panel
     Capture Page Screenshot    00-notebook-and-panel-opened.png
 

--- a/atest/04_Interface/Statusbar.robot
+++ b/atest/04_Interface/Statusbar.robot
@@ -14,7 +14,7 @@ ${HELP_BUTTON}      css:.lsp-popover .lsp-help-button
 *** Test Cases ***
 Statusbar Popup Opens
     Setup Notebook    Python    Python.ipynb
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${DIAGNOSTIC}"]    timeout=20s
+    Wait Until Page Contains Diagnostic    [title*="${DIAGNOSTIC}"]    timeout=20s
     Element Should Contain    ${STATUSBAR}    Fully initialized
     Click Element    ${STATUSBAR}
     Wait Until Page Contains Element    ${POPOVER}    timeout=10s

--- a/atest/05_Features/Diagnostics.robot
+++ b/atest/05_Features/Diagnostics.robot
@@ -11,7 +11,7 @@ Test Tags           feature:diagnostics
 
 *** Test Cases ***
 Diagnostics with deprecated tag have strike-through decoration
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="is deprecated"]    timeout=25s
-    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="Unreachable code"]    timeout=5s
+    Wait Until Page Contains Diagnostic    [title*="is deprecated"]    timeout=25s
+    Wait Until Page Contains Diagnostic    [title*="Unreachable code"]    timeout=5s
     Page Should Contain Element    css:.cm-lsp-diagnostic-tag-Deprecated
     Page Should Contain Element    css:.cm-lsp-diagnostic-tag-Unnecessary

--- a/atest/07_Configuration.robot
+++ b/atest/07_Configuration.robot
@@ -66,8 +66,8 @@ LaTeX
 *** Keywords ***
 Settings Should Change Editor Diagnostics
     [Arguments]    ${language}    ${file}    ${server}    ${settings}    ${before}    ${after}    ${save command}=${EMPTY}    ${needs reload}=${False}    ${setting_key}=serverSettings
-    ${before diagnostic} =    Set Variable    ${CSS DIAGNOSTIC}\[title*="${before}"]
-    ${after diagnostic} =    Set Variable    ${CSS DIAGNOSTIC}\[title*="${after}"]
+    ${before diagnostic} =    Set Variable    [title*="${before}"]
+    ${after diagnostic} =    Set Variable    [title*="${after}"]
     ${tab} =    Set Variable    ${JLAB XP DOCK TAB}\[contains(., '${file}')]
     ${close icon} =    Set Variable    *[contains(@class, 'm-TabBar-tabCloseIcon')]
     ${save command} =    Set Variable If    "${save command}"    ${save command}    Save ${language} File
@@ -95,9 +95,9 @@ Settings Should Change Editor Diagnostics
     IF    ${needs reload}
         Reload After Configuration    ${language}    ${file}
         # allow longer after reload
-        Wait Until Page Contains Element    ${after diagnostic}    timeout=60s
+        Wait Until Page Contains Diagnostic    ${after diagnostic}    timeout=60s
     ELSE
-        Wait Until Page Contains Element    ${after diagnostic}    timeout=30s
+        Wait Until Page Contains Diagnostic    ${after diagnostic}    timeout=30s
     END
     Capture Page Screenshot    04-configured-diagnostic-found.png
     [Teardown]    Clean Up After Working with File and Settings    ${file}

--- a/atest/Keywords.resource
+++ b/atest/Keywords.resource
@@ -9,6 +9,7 @@ Library     ./logcheck.py
 Library     ./ports.py
 Library     ./config.py
 Library     ./paths.py
+Library     ./diagnostics.py
 
 
 *** Keywords ***
@@ -334,7 +335,7 @@ Place Cursor In Cell Editor At
     Enter Cell Editor    ${cell_nr}    ${line}
     Execute JavaScript
     ...    var view = document.querySelector('.jp-Cell:nth-child(${cell_nr}) .cm-content').cmView.view;
-    ...    var pos = view.doc.line(${line}).from + ${character};
+    ...    var pos = view.state.doc.line(${line}).from + ${character};
     ...    return view.dispatch({selection: {anchor: pos, head: pos}});
 
 Enter File Editor
@@ -346,7 +347,7 @@ Place Cursor In File Editor At
     Enter File Editor
     Execute JavaScript
     ...    var view = document.querySelector('.jp-FileEditor .cm-content').cmView.view;
-    ...    var pos = view.doc.line(${line}).from + ${character};
+    ...    var pos = view.state.doc.line(${line}).from + ${character};
     ...    return view.dispatch({selection: {anchor: pos, head: pos}});
 
 Wait Until Fully Initialized
@@ -404,13 +405,16 @@ Set Editor Content
     [Arguments]    ${text}    ${css}=${EMPTY}
     Wait Until Page Contains Element    css:${css} .cm-content
     Execute JavaScript
-    ...    var doc = document.querySelector('${css} .cm-content').cmView.view.doc;
-    ...    return doc.replace(0, doc.length, `${text}`);
+    ...    let view = document.querySelector('${css} .cm-content').cmView.view;
+    ...    view.dispatch({
+    ...        changes: {from: 0, to: view.state.doc.length, insert: `${text}`}
+    ...    });
 
 Get Editor Content
     [Arguments]    ${css}=${EMPTY}
     Wait Until Page Contains Element    css:${css} .cm-content
-    ${content} =    Execute JavaScript    return document.querySelector('${css} .cm-content').cmView.view.doc.toString()
+    ${content} =    Execute JavaScript
+    ...    return document.querySelector('${css} .cm-content').cmView.view.state.doc.toString()
     RETURN    ${content}
 
 Configure JupyterLab Plugin
@@ -431,8 +435,9 @@ Jump To Definition
     [Arguments]    ${symbol}
     ${sel} =    Set Variable If    "${symbol}".startswith(("xpath", "css"))    ${symbol}
     ...    xpath:(//span[@role="presentation"][contains(., "${symbol}")])[last()]
-    Open Context Menu Over    ${sel}
+    Click Element    ${sel}
     ${cursor} =    Measure Cursor Position
+    Open Context Menu Over    ${sel}
     Capture Page Screenshot    02-jump-to-definition-0.png
     Wait Until Element Is Visible    ${MENU JUMP}    timeout=5s
     Mouse Over    ${MENU JUMP}
@@ -453,8 +458,11 @@ Cursor Should Jump
     Should Not Be Equal    ${original}    ${current}
 
 Measure Cursor Position
-    Wait Until Page Contains Element    ${CM CURSORS}
-    ${position} =    Wait Until Keyword Succeeds    20 x    0.05s    Get Vertical Position    ${CM CURSOR}
+    Wait Until Page Contains Element    ${ACTIVE CURSOR}
+    ${position} =    Wait Until Keyword Succeeds    20 x    0.05s    Get Vertical Position    ${ACTIVE CURSOR}
+    LOG     ${position}
+    # position = 0 indicates that the element was not active.
+    Should Not Be Equal    ${position}    0
     RETURN    ${position}
 
 Switch To Tab

--- a/atest/Variables.resource
+++ b/atest/Variables.resource
@@ -49,9 +49,8 @@ ${MENU SETTINGS}                xpath://div[contains(@class, 'lm-MenuBar-itemLab
 ${MENU EDITOR THEME}
 ...                             xpath://div[contains(@class, 'lm-Menu-itemLabel')][contains(text(), "Text Editor Theme")]
 ${LAB MENU}                     css:.lm-Menu
-${CM CURSOR}                    css:.cm-cursor
-${CM CURSORS}
-...                             css:.jp-MainAreaWidget:not(.lm-mod-hidden) .cm-cursorLayer:not([style='visibility: hidden'])
+${ACTIVE CURSOR}
+...                             css:.jp-MainAreaWidget:not(.lm-mod-hidden) .cm-cursorLayer:not([style='visibility: hidden']) .cm-cursor-primary
 # settings
 ${LSP PLUGIN ID}                @jupyter-lsp/jupyterlab-lsp:plugin
 ${COMPLETION PLUGIN ID}         @jupyter-lsp/jupyterlab-lsp:completion
@@ -62,8 +61,6 @@ ${HOVER PLUGIN ID}              @jupyter-lsp/jupyterlab-lsp:hover
 ${CSS USER SETTINGS}            .jp-SettingsRawEditor-user
 ${JLAB XP CLOSE SETTINGS}
 ...                             ${JLAB XP DOCK TAB}\[contains(., 'Settings')]/*[contains(@class, 'm-TabBar-tabCloseIcon')]
-# diagnostics
-${CSS DIAGNOSTIC}               css:.cm-lintRange
 # log messages
 @{KNOWN BAD ERRORS}
 ...                             pylsp_jsonrpc.endpoint - Failed to handle notification

--- a/atest/diagnostics.py
+++ b/atest/diagnostics.py
@@ -1,0 +1,45 @@
+from functools import partial
+from robot.libraries.BuiltIn import BuiltIn
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+from SeleniumLibrary import SeleniumLibrary
+
+from robot.utils import timestr_to_secs
+
+DIAGNOSTIC_CLASS = 'cm-lintRange'
+
+def page_contains_diagnostic(driver: WebDriver, selector, negate=False):
+    elements = driver.find_elements(By.CSS_SELECTOR, f'.{DIAGNOSTIC_CLASS}')
+    if not elements:
+        return True if negate else False
+    driver.execute_script("""
+    arguments[0].map(el => {
+      let diagnostic = el.cmView.mark.spec.diagnostic;
+      el.title = diagnostic.message + " (" + diagnostic.source + ")";
+    });
+    """, elements)
+    try:
+        driver.find_element(By.CSS_SELECTOR, f'.{DIAGNOSTIC_CLASS}{selector}')
+    except NoSuchElementException:
+        return True if negate else False
+    return False if negate else True
+
+
+def wait_until_page_contains_diagnostic(selector, timeout='3s'):
+    sl: SeleniumLibrary = BuiltIn().get_library_instance("SeleniumLibrary")
+    wait = WebDriverWait(sl.driver, timestr_to_secs(timeout))
+    return wait.until(
+      partial(page_contains_diagnostic, selector=selector),
+      f'Diagnostic with selector {selector} not found in {timeout}'
+    )
+
+
+def wait_until_page_does_not_contain_diagnostic(selector, timeout='3s'):
+    sl: SeleniumLibrary = BuiltIn().get_library_instance("SeleniumLibrary")
+    wait = WebDriverWait(sl.driver, timestr_to_secs(timeout))
+    return wait.until(
+      partial(page_contains_diagnostic, selector=selector, negate=True),
+      f'Diagnostic with selector {selector} still present after {timeout}'
+    )

--- a/packages/jupyterlab-lsp/src/features/jump_to.ts
+++ b/packages/jupyterlab-lsp/src/features/jump_to.ts
@@ -46,6 +46,7 @@ import { ContextAssembler } from '../context';
 import {
   PositionConverter,
   documentAtRootPosition,
+  editorAtRootPosition,
   rootPositionToVirtualPosition,
   rootPositionToEditorPosition,
   virtualPositionToRootPosition
@@ -367,7 +368,6 @@ export class NavigationFeature extends Feature {
     ) as IVirtualPosition;
 
     if (urisEqual(uri, positionParams.textDocument.uri)) {
-      let editorIndex = adapter.getEditorIndexAt(virtualPosition);
       // if in current file, transform from the position within virtual document to the editor position:
       const rootPosition = virtualPositionToRootPosition(
         adapter,
@@ -384,6 +384,19 @@ export class NavigationFeature extends Feature {
         adapter,
         rootPosition
       );
+
+      const editorAccessor = editorAtRootPosition(adapter, rootPosition);
+
+      // TODO: getEditorIndex should work, but does not
+      // adapter.getEditorIndex(editorAccessor)
+      await editorAccessor.reveal();
+      const editor = editorAccessor.getEditor();
+      const editorIndex = adapter.editors.findIndex(
+        e => e.ceEditor.getEditor() === editor
+      );
+      if (editorIndex === -1) {
+        return JumpResult.PositioningFailure;
+      }
 
       this.console.log(`Jumping to ${editorIndex}th editor of ${uri}`);
       this.console.log('Jump target within editor:', editorPosition);

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -544,14 +544,9 @@ export class SignatureFeature extends Feature {
       return;
     }
 
-    //let editorPosition =
-    //  virtualDocument.transformVirtualToEditor(virtualPosition);
-
     const editorLanguage = this.languageRegistry.findByMIME(
       editor.model.mimeType
     );
-    // TODO: restore language probing
-    // let language = cm_editor.getModeAt(editorPosition).name;
     const language = editorLanguage?.support?.language;
     let markup = this.getMarkupForSignatureHelp(response, language);
 


### PR DESCRIPTION
## References

Fixes #961

## Code changes

- implements a custom `Wait Until Page Contains Diagnostic` keyword

## User-facing changes

- fixes jump to in notebooks

## Backwards-incompatible changes

None