### PR TITLE
Fix issues identified in 5.0.0b0, prepare 5.0.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### `@jupyter-lsp/jupyterlab-lsp 5.0.0-beta.1`
+
+- fix highlights conflict with selection
+- fix scrolling to diagnostics and diagnostic rendering in windowed notebook
+- suppress kernel completer in transclusions
+
 ### `@jupyter-lsp/jupyterlab-lsp 5.0.0-beta.0`
 
 - fix most regressions caught by tests in alpha

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -151,7 +151,7 @@
       "@jupyterlab/lsp": {
         "bundled": false,
         "singleton": true,
-        "strictVersion": true
+        "strictVersion": false
       }
     },
     "schemaDir": "schema",

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-lsp/jupyterlab-lsp",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -231,7 +231,7 @@ class DiagnosticsPanel {
           console.warn('LPS: diagnostics row not found for jump execute()');
           return;
         }
-        this.widget.content.jumpTo(row);
+        return this.widget.content.jumpTo(row);
       },
       label: this.trans.__('Jump to location'),
       icon: jumpToIcon

--- a/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
@@ -286,7 +286,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
           let cellNumber: number | null = null;
           if (adapter.hasMultipleEditors) {
             const cellIndex = adapter.editors.findIndex(
-              value => value.ceEditor.getEditor() == diagnosticData.editor
+              value => value.ceEditor == diagnosticData.editorAccessor
             );
             cellNumber = cellIndex + 1;
           }
@@ -330,7 +330,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
           key={row.key}
           data-key={row.key}
           onClick={() => {
-            this.jumpTo(row);
+            return this.jumpTo(row);
           }}
         >
           {cells}
@@ -360,12 +360,10 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     return this._diagnostics.get(key);
   }
 
-  jumpTo(row: IDiagnosticsRow) {
-    const cmEditor = row.data.editor;
-    cmEditor.setCursorPosition(
-      PositionConverter.cm_to_ce(row.data.range.start)
-    );
-    cmEditor.focus();
+  async jumpTo(row: IDiagnosticsRow): Promise<void> {
+    const editor = await row.data.editorAccessor.reveal();
+    editor.setCursorPosition(PositionConverter.cm_to_ce(row.data.range.start));
+    editor.focus();
   }
 }
 

--- a/packages/jupyterlab-lsp/src/features/diagnostics/tokens.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/tokens.ts
@@ -1,5 +1,4 @@
-import { CodeMirrorEditor } from '@jupyterlab/codemirror';
-import { IEditorPosition, WidgetLSPAdapter } from '@jupyterlab/lsp';
+import { IEditorPosition, WidgetLSPAdapter, Document } from '@jupyterlab/lsp';
 import { Token } from '@lumino/coreutils';
 import * as lsProtocol from 'vscode-languageserver-protocol';
 
@@ -11,7 +10,7 @@ import { PLUGIN_ID } from '../../tokens';
  */
 export interface IEditorDiagnostic {
   diagnostic: lsProtocol.Diagnostic;
-  editor: CodeMirrorEditor;
+  editorAccessor: Document.IEditor;
   range: {
     start: IEditorPosition;
     end: IEditorPosition;

--- a/packages/jupyterlab-lsp/src/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/features/rename.ts
@@ -170,7 +170,7 @@ function guessFailureReason(
         let start = diagnostic.range.start;
         if (adapter.hasMultipleEditors) {
           let editorIndex = adapter.editors.findIndex(
-            e => e.ceEditor.getEditor() === diagnostic.editor
+            e => e.ceEditor === diagnostic.editorAccessor
           );
           let cellNumber = editorIndex === -1 ? '(?)' : editorIndex + 1;
           return trans.__(

--- a/packages/jupyterlab-lsp/style/highlight.css
+++ b/packages/jupyterlab-lsp/style/highlight.css
@@ -31,7 +31,7 @@
 .cm-lsp-highlight-Read {
   /* highlight on places where variable is accessed, e.g. `print(var)` */
   background-color: var(--jp-editor-mirror-lsp-highlight-background-color);
-  outline: 1px dashed var(--jp-editor-mirror-lsp-highlight-border-color);
+  outline: 1px solid var(--jp-editor-mirror-lsp-highlight-background-color);
 }
 
 .cm-lsp-highlight-Write {

--- a/packages/jupyterlab-lsp/style/variables/base.css
+++ b/packages/jupyterlab-lsp/style/variables/base.css
@@ -1,6 +1,10 @@
 :root {
   /* highlight */
-  --jp-editor-mirror-lsp-highlight-background-color: var(--jp-layout-color2);
+  --jp-editor-mirror-lsp-highlight-background-color: color-mix(
+    in srgb,
+    var(--jp-layout-color3) 25%,
+    transparent
+  );
   --jp-editor-mirror-lsp-highlight-border-color: var(--jp-layout-color3);
   /* diagnostics */
   --jp-editor-mirror-lsp-diagnostic-decoration-style: dashed;

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-lsp/jupyterlab-lsp-metapackage",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/jupyter-lsp/jupyterlab-lsp",
   "bugs": {


### PR DESCRIPTION
## References

Closes #969 
Closes #974 
Closes #973 

## Code changes

- implements `isApplicable` for kernel completion provider override
- switches to editor wrapper in diagnostics listing to enable scrolling to out-of-view cells
- improves support for windowed notebook but it is still imperfect (diagnostics may be not rendered if scrolling fast and then coming back)

## User-facing changes

Changes the colour of highlights to slightly darker and removes dotted outline. Feedback welcome.

## Backwards-incompatible changes

`IEditorDiagnostic` now uses `editorAccessor` instead of `editor`.