### PR TITLE
Restore re-use of unused standalone connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### `@jupyter-lsp/jupyterlab-lsp 5.0.0-rc.1`
+
 - restore re-use of unused standalone connections
 
 ### `@jupyter-lsp/jupyterlab-lsp 5.0.0-rc.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### `@jupyter-lsp/jupyterlab-lsp 5.0.0-rc.1`
+- restore re-use of unused standalone connections
+
 ### `@jupyter-lsp/jupyterlab-lsp 5.0.0-rc.0`
 
 - fixes diagnostics not showing up in text editor in certain circumstances

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-lsp/jupyterlab-lsp",
-  "version": "5.0.0-rc.0",
+  "version": "5.0.0-rc.1",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -220,15 +220,16 @@ export class VirtualDocument extends VirtualDocumentBase {
       foreignDocument = this.foreignDocuments.get(extractor.language)!;
     } else {
       // if standalone, try to re-use existing connection to the server
-       let unusedStandalone = this.unusedStandaloneDocuments.get(
-         extractor.language
-       );
-       if (extractor.standalone && unusedStandalone.length > 0) {
-         foreignDocument = unusedStandalone.pop()!;
-         this.unusedDocuments.delete(foreignDocument);
-       } else {
+      let unusedStandalone = this.unusedStandaloneDocuments.get(
+        extractor.language
+      );
+      if (extractor.standalone && unusedStandalone.length > 0) {
+        foreignDocument = unusedStandalone.pop()!;
+        this.unusedDocuments.delete(foreignDocument);
+      } else {
         // if (previous document does not exists) or (extractor produces standalone documents
         // and no old standalone document could be reused): create a new document
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         foreignDocument = this.openForeign(
           extractor.language,

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -4,7 +4,8 @@ import type {
   IVirtualPosition,
   IRootPosition,
   Document,
-  ForeignDocumentsMap
+  ForeignDocumentsMap,
+  IForeignCodeExtractor
 } from '@jupyterlab/lsp';
 import { VirtualDocument as VirtualDocumentBase } from '@jupyterlab/lsp';
 
@@ -33,6 +34,9 @@ export class VirtualDocument extends VirtualDocumentBase {
     this.lineMagicsOverrides = new ReversibleOverridesMap(
       overrides ? overrides.line : []
     );
+    // override private `chooseForeignDocument` as a workaround for
+    // https://github.com/jupyter-lsp/jupyterlab-lsp/issues/959
+    this['chooseForeignDocument'] = this._chooseForeignDocument;
   }
 
   // TODO: this could be moved out
@@ -201,5 +205,38 @@ export class VirtualDocument extends VirtualDocumentBase {
       }
     }
     return [...maps.values()];
+  }
+
+  /**
+   * Get the foreign document that can be opened with the input extractor.
+   */
+  private _chooseForeignDocument(
+    extractor: IForeignCodeExtractor
+  ): VirtualDocumentBase {
+    let foreignDocument: VirtualDocumentBase;
+    // if not standalone, try to append to existing document
+    let foreignExists = this.foreignDocuments.has(extractor.language);
+    if (!extractor.standalone && foreignExists) {
+      foreignDocument = this.foreignDocuments.get(extractor.language)!;
+    } else {
+      // if standalone, try to re-use existing connection to the server
+       let unusedStandalone = this.unusedStandaloneDocuments.get(
+         extractor.language
+       );
+       if (extractor.standalone && unusedStandalone.length > 0) {
+         foreignDocument = unusedStandalone.pop()!;
+         this.unusedDocuments.delete(foreignDocument);
+       } else {
+        // if (previous document does not exists) or (extractor produces standalone documents
+        // and no old standalone document could be reused): create a new document
+        // @ts-ignore
+        foreignDocument = this.openForeign(
+          extractor.language,
+          extractor.standalone,
+          extractor.fileExtension
+        );
+      }
+    }
+    return foreignDocument;
   }
 }

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-lsp/jupyterlab-lsp-metapackage",
-  "version": "5.0.0-rc.0",
+  "version": "5.0.0-rc.1",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/jupyter-lsp/jupyterlab-lsp",
   "bugs": {


### PR DESCRIPTION
## References

Workaround for #959 which should also reduce #988 to the upstream issue and unblock release of 5.0 without disabling transclusions support.

## Code changes

Override `chooseForeignDocument` method of virtual document to restore re-use of unused standalone documents.

## User-facing changes

None

## Backwards-incompatible changes

None