### PR TITLE
Fix false “undefined name” message caused by cell magic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1101,8 +1101,14 @@ Requires JupyterLab `>=3.6.0,<4.0.0a0` and Python 3.8 or newer.
 ### `jupyter-lsp 0.6.0b0`
 
 - features
+
   - starts language servers on demand
   - accepts configuration via Jupyter config system (traitlets) and python
     `entry_point`s
   - autodetects language servers for bash, CSS, LESS, SASS, Dockerfile, YAML, JS,
     TypeScript, JSX, TSX, JSON, YAML
+
+- bugfixes
+  - fix issue that variables declared in cell magics(%%time, %%capture) are masked(
+    [#635](https://github.com/jupyter-lsp/jupyterlab-lsp/issues/635)
+    )

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
@@ -70,7 +70,7 @@ describe('Default IPython overrides', () => {
     });
 
     it('some cell magic commands are unwrapped', () => {
-      const cellMagicToUnwrap = "%%capture --no-display\ntext";
+      const cellMagicToUnwrap = '%%capture --no-display\ntext';
       let override = cellMagicsMap.overrideFor(cellMagicToUnwrap)!;
       expect(override).toBe(
         '# START_CELL_MAGIC("capture", " --no-display")\ntext\n# END_CELL_MAGIC'

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
@@ -69,6 +69,17 @@ describe('Default IPython overrides', () => {
       expect(reverse).toBe(cellMagicWithArgs);
     });
 
+    it('some cell magic commands are unwrapped', () => {
+      const cellMagicToUnwrap = "%%capture --no-display\ntext";
+      let override = cellMagicsMap.overrideFor(cellMagicToUnwrap)!;
+      expect(override).toBe(
+        '# START_CELL_MAGIC("capture", " --no-display")\ntext\n# END_CELL_MAGIC'
+      );
+
+      let reverse = cellMagicsMap.reverse.overrideFor(override);
+      expect(reverse).toBe(cellMagicToUnwrap);
+    });
+
     it('escapes docstrings properly', () => {
       let override = cellMagicsMap.overrideFor(CELL_MAGIC_WITH_DOCSTRINGS)!;
       expect(override).toBe(

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
@@ -16,7 +16,7 @@ function emptyOrEscaped(x: string) {
   }
 }
 
-const MAGICS_TO_UNWRAP = ["time", "capture"]
+const MAGICS_TO_UNWRAP = ['time', 'capture'];
 
 function unwrapCellMagic(name: string, firstLine: string, content: string) {
   return `# START_CELL_MAGIC("${name}", "${firstLine}")
@@ -140,22 +140,26 @@ export let overrides: IScopedCodeOverride[] = [
       }
       content = content.replace(/"""/g, '\\"\\"\\"');
 
-      let replaced: string
+      let replaced: string;
       if (MAGICS_TO_UNWRAP.includes(name)) {
-        replaced = unwrapCellMagic(name, firstLine, content)
-      }else{
+        replaced = unwrapCellMagic(name, firstLine, content);
+      } else {
         replaced = `get_ipython().run_cell_magic("${name}", "${firstLine}", """${content}""")`;
       }
-      return replaced
+      return replaced;
     },
     scope: 'cell',
     reverse: {
-      pattern:"^get_ipython[\\s\\S]*|^# START_CELL_MAGIC[\\s\\S]*",
-      replacement: (code) => {
-        const regCellMagic = RegExp('^get_ipython\\(\\).run_cell_magic\\("(.*?)", "(.*?)", """([\\s\\S]*)"""\\)');
-        const regUnwrapped = RegExp('^# START_CELL_MAGIC\\("(.*?)", "(.*?)"\\)\n([\\s\\S]*)\n# END_CELL_MAGIC$');
+      pattern: '^get_ipython[\\s\\S]*|^# START_CELL_MAGIC[\\s\\S]*',
+      replacement: code => {
+        const regCellMagic = RegExp(
+          '^get_ipython\\(\\).run_cell_magic\\("(.*?)", "(.*?)", """([\\s\\S]*)"""\\)'
+        );
+        const regUnwrapped = RegExp(
+          '^# START_CELL_MAGIC\\("(.*?)", "(.*?)"\\)\n([\\s\\S]*)\n# END_CELL_MAGIC$'
+        );
         let m = code.match(regCellMagic) || code.match(regUnwrapped);
-        let [name, line, content] = m?.slice(1, 4) || ["", "", ""]
+        let [name, line, content] = m?.slice(1, 4) || ['', '', ''];
         content = content.replace(/\\"\\"\\"/g, '"""');
         line = unescape(line);
         return `%%${name}${line}\n${content}`;

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
@@ -156,7 +156,7 @@ export let overrides: IScopedCodeOverride[] = [
           '^get_ipython\\(\\).run_cell_magic\\("(.*?)", "(.*?)", """([\\s\\S]*)"""\\)'
         );
         const regUnwrapped = RegExp(
-          '^# START_CELL_MAGIC\\("(.*?)", "(.*?)"\\)\n([\\s\\S]*)\n# END_CELL_MAGIC$'
+          '^# START_CELL_MAGIC\\("(.*?)", "(.*?)"\\)\\n([\\s\\S]*)\\n# END_CELL_MAGIC$'
         );
         let m = code.match(regCellMagic) || code.match(regUnwrapped);
         let [name, line, content] = m?.slice(1, 4) || ['', '', ''];


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->



## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above).
Use "fixes" and "closes" linking phrases as appropriate. -->
In this PR, I want to fix #635. 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

According to the comment in #635, I implemented another transformation to the specific cell magics.

From:
```py
%%capture --no-display
x = 1
```
To:
```py
# START_CELL_MAGIC("capture", "--no-display")
x = 1
# END_CELL_MAGIC
```
Instead of:
```py
get_ipython().run_cell_magic("capture", "--no-display", """x=1""")
```

Currently, the target cell magics are hard coded (%%time, %%capture).
It would be better if the list is configurable.
Since I'm new to the project, I need more time to figure out how to make the list configurable, but I will try this in the near future.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

As pointed out in #635, variables defined inside cell magics are not recognized by the lsp, and `undefined name` message shows up.
This PR tries to remove these false messages.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->
No

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
