### PR TITLE
Workaround issue with markdown lost on edit

### DIFF
--- a/packages/jupyterlab-lsp/src/edits.ts
+++ b/packages/jupyterlab-lsp/src/edits.ts
@@ -189,6 +189,14 @@ export class EditApplicator {
     if (!editor) {
       throw Error('Editor is not accessible');
     }
+    if (editor.host.closest('.jp-MarkdownCell')) {
+      // Workaround for https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1008
+      // briefly, the rewrite for JupyterLab 4.0 added Markdown cell support, but they
+      // are extracted without trace in the top-level document. Here we avoid editing
+      // any markdown cell. Instead the clean solution would be to add an anchor marker
+      // to the top-level document.
+      return 0;
+    }
     // TODO: should accessor present the model even if editor is not created yet?
     const model = editor.model;
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
@@ -164,7 +164,7 @@ def setup_shadow_filesystem(virtual_documents_uri: str):
                         "[lsp] initialization of shadow filesystem failed three times"
                         " check if the path set by `LanguageServerManager.virtual_documents_dir`"
                         " or `JP_LSP_VIRTUAL_DIR` is correct; if this is happening with a server"
-                        " for which which you control (or wish to override) jupyter-lsp specification"
+                        " for which you control (or wish to override) jupyter-lsp specification"
                         " you can try switching `requires_documents_on_disk` off. The errors were: %s",
                         failures,
                     )


### PR DESCRIPTION
## References

Hotfix for #1008
