### PR TITLE
Do not pre-filter completions from kernel

### DIFF
--- a/packages/jupyterlab-lsp/jest.config.js
+++ b/packages/jupyterlab-lsp/jest.config.js
@@ -23,12 +23,11 @@ const esModules = [
 ].join('|');
 
 let local = {
-  globals: { 'ts-jest': { tsconfig: 'tsconfig.json' } },
   testRegex: `.*\.spec\.tsx?$`,
   transformIgnorePatterns: [`/node_modules/(?!${esModules}).*`],
   testLocationInResults: true,
   transform: {
-    '\\.(ts|tsx)?$': 'ts-jest',
+    '\\.(ts|tsx)?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
     '\\.(js|jsx)?$': './transform.js',
     '\\.svg$': '@jupyterlab/testing/lib/jest-raw-loader.js'
   },

--- a/packages/jupyterlab-lsp/src/features/completion/model.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.ts
@@ -94,7 +94,7 @@ export class GenericCompleterModel<
     return super.createPatch(patch);
   }
 
-  resolveQuery(userQuery: string, _item: T) {
+  protected resolveQuery(userQuery: string, _item: T) {
     return userQuery;
   }
 
@@ -283,7 +283,7 @@ export class LSPCompleterModel extends GenericCompleterModel<MaybeCompletionItem
     }
   }
 
-  resolveQuery(userQuery: string, item: MaybeCompletionItem) {
+  protected resolveQuery(userQuery: string, item: MaybeCompletionItem) {
     return userQuery
       ? userQuery
       : item.source === 'LSP'


### PR DESCRIPTION

## References

- fixes https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1014
- fixes https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1009
- fixes https://github.com/jupyter-lsp/jupyterlab-lsp/issues/704

## Code changes

Moves pre-filtering to LSP model which now checks if the item came from LSP
