### PR TITLE
Fix completion provider `isApplicable()` for Console

### DIFF
--- a/packages/jupyterlab-lsp/src/features/completion/overrides.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/overrides.ts
@@ -93,6 +93,10 @@ export class EnhancedKernelCompleterProvider extends KernelCompleterProvider {
 
     const manager = this.options.connectionManager;
     const widget = context.widget as IDocumentWidget;
+    if (typeof widget.context === 'undefined') {
+      // there is no path for Console as it is not a DocumentWidget
+      return upstream;
+    }
     const adapter = manager.adapters.get(widget.context.path);
 
     if (!adapter) {

--- a/packages/jupyterlab-lsp/src/features/completion/provider.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/provider.ts
@@ -301,6 +301,10 @@ export class CompletionProvider implements ICompletionProvider<CompletionItem> {
     }
     const manager = this.options.connectionManager;
     const widget = context.widget as IDocumentWidget;
+    if (typeof widget.context === 'undefined') {
+      // there is no path for Console as it is not a DocumentWidget
+      return false;
+    }
     const adapter = manager.adapters.get(widget.context.path);
     if (!adapter) {
       return false;


### PR DESCRIPTION
## References

Fixes https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1006

## Code changes

Check if we can access `path` of the widget rather than assuming it is always 

## User-facing changes

Kernel/context completions in console are no longer broken (although LSP completions are still not available)

## Backwards-incompatible changes

None