### PR TITLE
Fix transclusions in JupyterLab 4.0.7+

### DIFF
--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -225,7 +225,6 @@ export class VirtualDocument extends VirtualDocumentBase {
       );
       if (extractor.standalone && unusedStandalone.length > 0) {
         foreignDocument = unusedStandalone.pop()!;
-        this.unusedDocuments.delete(foreignDocument);
       } else {
         // if (previous document does not exists) or (extractor produces standalone documents
         // and no old standalone document could be reused): create a new document


### PR DESCRIPTION
## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/15105

## Code changes

Remove reference to upstream variable `unusedDocuments`; this variable was removed in `JupyterLab 4.0.7` (as it should have never been there)

## User-facing changes

Transclusions should work more reliably in newer lab versions

## Backwards-incompatible changes

None