### PR TITLE
Prepare jupyterlab-lsp 5.1.0 and jupyter-lsp 2.2.3 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,30 @@
 
 ### `@jupyter-lsp/jupyterlab-lsp 5.1.0`
 
-> TBD
-
-### `jupyter-lsp 2.2.2`
-
-> TBD
-
 Requires JupyterLab `>=4.1.0,<5.0.0a0`
+
+- new features:
+  - populate table of contents with code symbols outline (experimental, file editor only)
+- bug fixes:
+  - fix settings reconciliation for nested properties (#1051)
+  - fix a regression introduced in v5.0.2 which meant that overrides for native kernel and context completion providers were never active (#1057)
+  - reduces some warnings in places known to have false positives to debug statements (#1057)
+  - highlights no longer get instantly removed when navigating to a beginning of cell from another cell (#1057)
+  - with the use of the new `extensionFactory` API (#1057):
+    - LSP features work more reliably as the correct virtual document and editor is known rather than found from heuristics
+    - LSP CodeMirror extensions are not added to editors which do not have an LSP-enabled editor reducing spurious warnings and improving performance
+    - LSP CodeMirror extensions are only added once the LSP server was connected
+- maintenance:
+  - use new `extensionFactory` API allowing to remove workarounds that were needed to make the extension work in JupyterLab 4.0 (#1057)
+  - remove no-longer needed patches for `VirtualDocument` as these were merged upstream and released in JupyterLab 4.1 (#1057)
+  - update coverage, robot version and reporting approaches (#1052)
+  - build against JupyterLab 4.1, fix tests (#1057)
+  - bump ip from 2.0.0 to 2.0.1 (#1055)
+
+### `jupyter-lsp 2.2.3`
+
+- maintenance:
+  - updates pyright config schema to v1.1.350
 
 ### `@jupyter-lsp/jupyterlab-lsp 5.0.3`
 

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-lsp/jupyterlab-lsp",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/jupyterlab-lsp/src/adapters/fileeditor.ts
+++ b/packages/jupyterlab-lsp/src/adapters/fileeditor.ts
@@ -12,7 +12,8 @@ import {
 import {
   ILSPCodeExtractorsManager,
   ILSPFeatureManager,
-  ILSPDocumentConnectionManager
+  ILSPDocumentConnectionManager,
+  IEditorChangedData
 } from '@jupyterlab/lsp';
 
 import { ILSPCodeOverridesManager } from '../overrides/tokens';
@@ -28,6 +29,18 @@ export class FileEditorAdapter extends UpstreamFileEditorAdapter {
     protected options: IAdapterOptions
   ) {
     super(editorWidget, options);
+    // Workaround to ensure `_editorAdded` is not called twice once upstream
+    // adopts patch https://github.com/jupyterlab/jupyterlab/pull/15873
+    let emitted = false;
+    const emit = this._editorAdded.emit;
+    this._editorAdded.emit = (args: IEditorChangedData) => {
+      if (emitted) {
+        return;
+      }
+      emitted = true;
+      console.log('call');
+      emit.call(this._editorAdded, args);
+    };
   }
 
   protected async initOnceReady(): Promise<void> {

--- a/packages/jupyterlab-lsp/src/features/symbol.ts
+++ b/packages/jupyterlab-lsp/src/features/symbol.ts
@@ -274,10 +274,11 @@ export class SymbolFeature extends Feature {
     }
     const connection = this.connectionManager.connections.get(
       adapter.virtualDocument.uri
-    )!;
+    );
 
     if (
       !(
+        connection &&
         connection.isReady &&
         connection.serverCapabilities.documentSymbolProvider
       )

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-lsp/jupyterlab-lsp-metapackage",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/jupyter-lsp/jupyterlab-lsp",
   "bugs": {

--- a/python_packages/jupyter_lsp/jupyter_lsp/_version.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/_version.py
@@ -1,4 +1,4 @@
 """ single source of truth for jupyter_lsp version
 """
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"


### PR DESCRIPTION
## References

Fixes #1060

## Code changes

- Patch emit to only emit once
- Patch wrong non-null assertion
