### PR TITLE
Fix websocket handler and remove spurious config for old notebook server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### `jupyter-lsp 2.2.4`
+
+- bug fixes:
+  - fix websocket handler incorrectly inheriting from `APIHandler` rather than `JupyterHandler` (#1069)
+  - remove unused notebook config entry point (#1069)
+  - support latest version of `typescript-language-server` (#1064)
+
 ### `@jupyter-lsp/jupyterlab-lsp 5.1.0`
 
 Requires JupyterLab `>=4.1.0,<5.0.0a0`

--- a/python_packages/jupyter_lsp/jupyter_lsp/_version.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/_version.py
@@ -1,4 +1,4 @@
 """ single source of truth for jupyter_lsp version
 """
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"

--- a/python_packages/jupyter_lsp/jupyter_lsp/etc/jupyter-lsp-notebook.json
+++ b/python_packages/jupyter_lsp/jupyter_lsp/etc/jupyter-lsp-notebook.json
@@ -1,7 +1,0 @@
-{
-  "NotebookApp": {
-    "nbserver_extensions": {
-      "jupyter_lsp": true
-    }
-  }
-}

--- a/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
@@ -4,7 +4,7 @@
 from typing import Optional, Text
 
 from jupyter_core.utils import ensure_async
-from jupyter_server.base.handlers import APIHandler
+from jupyter_server.base.handlers import APIHandler, JupyterHandler
 from jupyter_server.utils import url_path_join as ujoin
 from tornado import web
 from tornado.websocket import WebSocketHandler
@@ -37,8 +37,15 @@ class BaseHandler(APIHandler):
         self.manager = manager
 
 
+class BaseJupyterHandler(JupyterHandler):
+    manager = None  # type: LanguageServerManager
+
+    def initialize(self, manager: LanguageServerManager):
+        self.manager = manager
+
+
 class LanguageServerWebSocketHandler(  # type: ignore
-    WebSocketMixin, WebSocketHandler, BaseHandler
+    WebSocketMixin, WebSocketHandler, BaseJupyterHandler
 ):
     """Setup tornado websocket to route to language server sessions.
 


### PR DESCRIPTION
## References

- Fixes #1068
- Fixes #1067

## Code changes

- Use `JupyterHandler` with `WebsocketMixin` as websocket is not an JSON API handler
- Remove spurious config for old notebook server

## User-facing changes

Works with latest jupyter-sever

## Backwards-incompatible changes

None
