### PR TITLE
Fix environment variables leaking into the parent environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### `jupyter-lsp 2.2.5`
+
+- bug fixes:
+  - fix for environment variables leaking into the parent environment (#1078)
+
 ### `jupyter-lsp 2.2.4`
 
 - bug fixes:

--- a/python_packages/jupyter_lsp/jupyter_lsp/_version.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/_version.py
@@ -1,4 +1,4 @@
 """ single source of truth for jupyter_lsp version
 """
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"

--- a/python_packages/jupyter_lsp/jupyter_lsp/session.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/session.py
@@ -6,7 +6,6 @@ import atexit
 import os
 import string
 import subprocess
-from copy import copy
 from datetime import datetime, timezone
 
 from tornado.ioloop import IOLoop
@@ -161,7 +160,7 @@ class LanguageServerSession(LoggingConfigurable):
         )
 
     def substitute_env(self, env, base):
-        final_env = copy(os.environ)
+        final_env = base.copy()
 
         for key, value in env.items():
             final_env.update({key: string.Template(value).safe_substitute(base)})

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_session.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_session.py
@@ -104,8 +104,10 @@ async def test_ping(handlers):
 
 
 @pytest.mark.asyncio
-async def test_substitute_env(known_server, handlers, jsonrpc_init_msg):
+async def test_substitute_env(handlers):
     """should not leak environment variables"""
+    a_server = "pylsp"
+
     handler, ws_handler = handlers
     manager = handler.manager
 
@@ -113,7 +115,7 @@ async def test_substitute_env(known_server, handlers, jsonrpc_init_msg):
 
     await assert_status_set(handler, {"not_started"})
 
-    await ws_handler.open(known_server)
+    await ws_handler.open(a_server)
     session = manager.sessions[ws_handler.language_server]
     new_env = session.substitute_env({"test-variable": "value"}, os.environ)
 


### PR DESCRIPTION
## References

Closes https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1076

## Code changes

Use `os._Environ.copy` instead of `copy.copy` to copy the environment

## User-facing changes

None

## Backwards-incompatible changes

None