### PR TITLE
Don't test for cursor position on `mousemove` if the widget adapter is not connected

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -62,7 +62,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: requirements/github-actions.yml
-          mamba-version: "*"
+          mamba-version: '*'
           channels: conda-forge,nodefaults
           channel-priority: true
 
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Python and mamba
         uses: conda-incubator/setup-miniconda@v3
         with:
-          mamba-version: "*"
+          mamba-version: '*'
           channels: conda-forge,nodefaults
           channel-priority: true
 
@@ -239,7 +239,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           environment-file: requirements/github-actions.yml
-          mamba-version: "*"
+          mamba-version: '*'
           channels: conda-forge,nodefaults
           channel-priority: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### `@jupyter-lsp/jupyterlab-lsp (next)`
+
+- bug fixes:
+  - Don't look at editor under the mouse on mouse motion when the widget adapter is not connected ([#1113](https://github.com/jupyter-lsp/jupyterlab-lsp/issues/1113))
+
 ### `jupyter-lsp 2.2.5`
 
 - bug fixes:

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -194,6 +194,10 @@ export class HoverFeature extends Feature {
         });
         const eventListeners = EditorView.domEventHandlers({
           mousemove: event => {
+            // Bail early if the adapter is not connected - and therefore no tooltip can be displayed
+            if (!adapter.isConnected) {
+              return;
+            }
             // this is used to hide the tooltip on leaving cells in notebook
             this.updateUnderlineAndTooltip(event, adapter)
               ?.then(keepTooltip => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16799,17 +16799,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-jsonrpc@npm:8.0.2, vscode-jsonrpc@npm:^8.0.2":
+"vscode-jsonrpc@npm:8.0.2":
   version: 8.0.2
   resolution: "vscode-jsonrpc@npm:8.0.2"
   checksum: 9d055fd4c87ef1093b0eecb5370bfaf3402179b6639149b6d0f7e0bde60cf580091c7e07b0caff868f10f90331b17e7383c087217c077fdd1b5ae7bc23b72f77
-  languageName: node
-  linkType: hard
-
-"vscode-jsonrpc@npm:8.2.0":
-  version: 8.2.0
-  resolution: "vscode-jsonrpc@npm:8.2.0"
-  checksum: f302a01e59272adc1ae6494581fa31c15499f9278df76366e3b97b2236c7c53ebfc71efbace9041cfd2caa7f91675b9e56f2407871a1b3c7f760a2e2ee61484a
   languageName: node
   linkType: hard
 
@@ -16824,6 +16817,13 @@ __metadata:
   version: 5.0.1
   resolution: "vscode-jsonrpc@npm:5.0.1"
   checksum: a9188774d8d9ceb4e0d2215aa71bd85bb9f4e1129d5decfda74587e791c6a2b532b2e0026931b45c52087c328429be6510ef841e203293ede7ed4114bb596cd0
+  languageName: node
+  linkType: hard
+
+"vscode-jsonrpc@npm:^8.0.2":
+  version: 8.2.0
+  resolution: "vscode-jsonrpc@npm:8.2.0"
+  checksum: f302a01e59272adc1ae6494581fa31c15499f9278df76366e3b97b2236c7c53ebfc71efbace9041cfd2caa7f91675b9e56f2407871a1b3c7f760a2e2ee61484a
   languageName: node
   linkType: hard
 
@@ -16887,7 +16887,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-languageserver-protocol@npm:3.17.2, vscode-languageserver-protocol@npm:^3.10.3, vscode-languageserver-protocol@npm:^3.15.3, vscode-languageserver-protocol@npm:^3.17.0, vscode-languageserver-protocol@npm:^3.7.2":
+"vscode-languageserver-protocol@npm:3.17.2, vscode-languageserver-protocol@npm:^3.10.3, vscode-languageserver-protocol@npm:^3.15.0, vscode-languageserver-protocol@npm:^3.15.3, vscode-languageserver-protocol@npm:^3.17.0, vscode-languageserver-protocol@npm:^3.7.2":
   version: 3.17.2
   resolution: "vscode-languageserver-protocol@npm:3.17.2"
   dependencies:
@@ -16904,16 +16904,6 @@ __metadata:
     vscode-jsonrpc: 3.5.0
     vscode-languageserver-types: 3.5.0
   checksum: b0659122b320de9d3d11ab09c5f381034b9775a56fb0e14cbfa0d7e3d44527454b1a101831505978a5a461c8c2f260f889e98574096538dc5a7ca0b0b8d529d1
-  languageName: node
-  linkType: hard
-
-"vscode-languageserver-protocol@npm:^3.15.0":
-  version: 3.17.5
-  resolution: "vscode-languageserver-protocol@npm:3.17.5"
-  dependencies:
-    vscode-jsonrpc: 8.2.0
-    vscode-languageserver-types: 3.17.5
-  checksum: dfb42d276df5dfea728267885b99872ecff62f6c20448b8539fae71bb196b420f5351c5aca7c1047bf8fb1f89fa94a961dce2bc5bf7e726198f4be0bb86a1e71
   languageName: node
   linkType: hard
 
@@ -16966,17 +16956,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-languageserver-types@npm:3.17.2, vscode-languageserver-types@npm:^3.13.0, vscode-languageserver-types@npm:^3.16.0, vscode-languageserver-types@npm:^3.17.0-next.3, vscode-languageserver-types@npm:^3.7.2":
+"vscode-languageserver-types@npm:3.17.2":
   version: 3.17.2
   resolution: "vscode-languageserver-types@npm:3.17.2"
   checksum: ef2d862d22f622b64de0f428773d50a5928ec6cdd485960a7564ebe4fd4a3c8bcd956f29eb15bc45a0f353846e62f39f6c764d2ab85ce774b8724411ba84342f
-  languageName: node
-  linkType: hard
-
-"vscode-languageserver-types@npm:3.17.5":
-  version: 3.17.5
-  resolution: "vscode-languageserver-types@npm:3.17.5"
-  checksum: 79b420e7576398d396579ca3a461c9ed70e78db4403cd28bbdf4d3ed2b66a2b4114031172e51fad49f0baa60a2180132d7cb2ea35aa3157d7af3c325528210ac
   languageName: node
   linkType: hard
 
@@ -16984,6 +16967,13 @@ __metadata:
   version: 3.5.0
   resolution: "vscode-languageserver-types@npm:3.5.0"
   checksum: 44c859700cfda71b5d3ff1224b5a1df093b39ec6755c8beb12fc76d1fbdb1a4948f55c3a97768356a1cbfb4e3ce66c5e4380e25f66bafcbd2db50277f68ee989
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-types@npm:^3.13.0, vscode-languageserver-types@npm:^3.16.0, vscode-languageserver-types@npm:^3.17.0-next.3, vscode-languageserver-types@npm:^3.7.2":
+  version: 3.17.5
+  resolution: "vscode-languageserver-types@npm:3.17.5"
+  checksum: 79b420e7576398d396579ca3a461c9ed70e78db4403cd28bbdf4d3ed2b66a2b4114031172e51fad49f0baa60a2180132d7cb2ea35aa3157d7af3c325528210ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above).
Use "fixes" and "closes" linking phrases as appropriate. -->
Fixes #1113
<!-- Note any other pull requests that address this issue and how this pull request is different. -->


## Code changes

<!-- Describe the code changes and how they address the issue. -->

Bail early on mouse motion DOM event handler if the widget adapter is not connected.
This avoid doing DOM computation and displaying noisy log file on file not supporting LSP.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

**Before**

https://github.com/user-attachments/assets/13925c4c-3eb2-466d-b30a-159d9b8ac985

**After**

https://github.com/user-attachments/assets/fcfb462f-e6f4-4b10-a182-a046b727f27d



<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
