### PR TITLE
Fix URL in docs

### DIFF
--- a/docs/Configuring.ipynb
+++ b/docs/Configuring.ipynb
@@ -18,7 +18,7 @@
     "files][notebook-config] in _well-known locations_. You can find out where to put\n",
     "them on your system with:\n",
     "\n",
-    "[notebook-config]: https://jupyter-notebook.readthedocs.io/en/stable/config.html\n",
+    "[notebook-config]: https://jupyter-notebook.readthedocs.io/en/stable/configuring/config_overview.html\n",
     "\n",
     "```bash\n",
     "jupyter --paths\n",


### PR DESCRIPTION
The old link is dead, edited from the Github web UI
