### PR TITLE
Allow to disable LSP toolbar item in Notebook view

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -374,6 +374,11 @@ jobs:
         with:
           name: jupyterlab-lsp dist ${{ github.run_number }}
           path: ./dist
+      - name: Create testing environment
+        run: |
+          set -eux
+          python3 -m venv .venv
+          source .venv/bin/activate
       - name: Install the prerequisites
         run: ${{ matrix.py_cmd }} -m pip install pip wheel
       - name: Install the package

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -377,24 +377,28 @@ jobs:
       - name: Create testing environment
         run: |
           set -eux
-          python3 -m venv .venv
-          source .venv/bin/activate
+          ${{ matrix.py_cmd }} -m venv .venv
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "VENV_PYTHON=.venv/Scripts/python.exe" >> $GITHUB_ENV
+          else
+            echo "VENV_PYTHON=.venv/bin/python" >> $GITHUB_ENV
+          fi
       - name: Install the prerequisites
-        run: ${{ matrix.py_cmd }} -m pip install pip wheel
+        run: $VENV_PYTHON -m pip install pip wheel
       - name: Install the package
-        run: cd dist && ${{ matrix.py_cmd }} -m pip install -vv ${{ matrix.dist }} 'jupyterlab${{ matrix.lab }}'
+        run: cd dist && $VENV_PYTHON -m pip install -vv ${{ matrix.dist }} 'jupyterlab${{ matrix.lab }}'
       - name: Validate environment
         run: |
           set -eux
-          ${{ matrix.py_cmd }} -m pip freeze
-          ${{ matrix.py_cmd }} -m pip check
+          $VENV_PYTHON -m pip freeze
+          $VENV_PYTHON -m pip check
       - name: Validate the install
         run: |
           set -eux
-          ${{ matrix.py_cmd }} -m jupyter labextension list
-          ${{ matrix.py_cmd }} -m jupyter server extension list
-          ${{ matrix.py_cmd }} -m jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp.*enabled.*ok" -
-          ${{ matrix.py_cmd }} -m jupyter server extension list 2>&1 | grep -ie "jupyter_lsp.*enabled" -
+          $VENV_PYTHON -m jupyter labextension list
+          $VENV_PYTHON -m jupyter server extension list
+          $VENV_PYTHON -m jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp.*enabled.*ok" -
+           -m jupyter server extension list 2>&1 | grep -ie "jupyter_lsp.*enabled" -
 
   source:
     name: smoke source install ${{ matrix.os }} py${{ matrix.python }} lab${{ matrix.lab }}

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -399,7 +399,7 @@ jobs:
           "$VENV_PYTHON" -m jupyter labextension list
           "$VENV_PYTHON" -m jupyter server extension list
           "$VENV_PYTHON" -m jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp.*enabled.*ok" -
-           -m jupyter server extension list 2>&1 | grep -ie "jupyter_lsp.*enabled" -
+          "$VENV_PYTHON" -m jupyter server extension list 2>&1 | grep -ie "jupyter_lsp.*enabled" -
 
   source:
     name: smoke source install ${{ matrix.os }} py${{ matrix.python }} lab${{ matrix.lab }}

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -337,7 +337,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: ['ubuntu', 'macos', 'windows']
-        python: ['3.9', '3.12', 'pypy-3.9']
+        python: ['3.9', '3.12']
         include:
           - python: '3.9'
             dist: 'jupyter*lsp*.whl'
@@ -347,9 +347,6 @@ jobs:
             lab: '>=4.1.0,<5'
           - python: '3.12'
             dist: 'jupyter*lsp*.whl'
-            lab: '>=4.1.0,<5'
-          - python: 'pypy-3.9'
-            dist: 'jupyter*lsp*.tar.gz'
             lab: '>=4.1.0,<5'
           - os: 'windows'
             py_cmd: python
@@ -362,8 +359,6 @@ jobs:
           # see https://github.com/actions/setup-python/issues/906
           - os: macos
             python: '3.9'
-          - os: macos
-            python: 'pypy-3.9'
     steps:
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -379,25 +379,26 @@ jobs:
           set -eux
           ${{ matrix.py_cmd }} -m venv .venv
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            echo "VENV_PYTHON=.venv/Scripts/python.exe" >> $GITHUB_ENV
+            VENV_PYTHON="$(pwd -W)\\\.venv\\Scripts\\python.exe"
           else
-            echo "VENV_PYTHON=.venv/bin/python" >> $GITHUB_ENV
+            VENV_PYTHON="$(pwd)/.venv/bin/python"
           fi
+          echo "VENV_PYTHON=$VENV_PYTHON" >> "$GITHUB_ENV"
       - name: Install the prerequisites
         run: $VENV_PYTHON -m pip install pip wheel
       - name: Install the package
-        run: cd dist && $VENV_PYTHON -m pip install -vv ${{ matrix.dist }} 'jupyterlab${{ matrix.lab }}'
+        run: cd dist && "$VENV_PYTHON" -m pip install -vv ${{ matrix.dist }} 'jupyterlab${{ matrix.lab }}'
       - name: Validate environment
         run: |
           set -eux
-          $VENV_PYTHON -m pip freeze
-          $VENV_PYTHON -m pip check
+          "$VENV_PYTHON" -m pip freeze
+          "$VENV_PYTHON" -m pip check
       - name: Validate the install
         run: |
           set -eux
-          $VENV_PYTHON -m jupyter labextension list
-          $VENV_PYTHON -m jupyter server extension list
-          $VENV_PYTHON -m jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp.*enabled.*ok" -
+          "$VENV_PYTHON" -m jupyter labextension list
+          "$VENV_PYTHON" -m jupyter server extension list
+          "$VENV_PYTHON" -m jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp.*enabled.*ok" -
            -m jupyter server extension list 2>&1 | grep -ie "jupyter_lsp.*enabled" -
 
   source:

--- a/atest/suites/03_Notebook.robot
+++ b/atest/suites/03_Notebook.robot
@@ -56,7 +56,7 @@ Foreign Extractors
     @{diagnostics} =    Create List
     ...    Double quote to prevent globbing and word splitting    # bash, configured by spec.env
     ...    ame 'valid'    # python, mypy and pyflakes will fight over `(N|n)ame 'valid'`, just hope for the best
-    ...    (lintr).    # r
+    ...    (lintr)    # r
     ...    `frob` is misspelt    # markdown
     ...    Command terminated with space    # latex
     FOR    ${diagnostic}    IN    @{diagnostics}

--- a/atest/suites/03_Notebook.robot
+++ b/atest/suites/03_Notebook.robot
@@ -54,11 +54,11 @@ Foreign Extractors
     Reset Application State
     Setup Notebook    Python    ${file}
     @{diagnostics} =    Create List
-    ...    (shellcheck)    # bash, configured by spec.env
-    ...    (pyflakes)'    # Python
-    ...    (lintr)    # r
-    ...    (retext-spell)    # markdown
-    ...    (ChkTeX)    # latex
+    ...    Double quote to prevent globbing and word splitting    # bash, configured by spec.env
+    ...    ame 'valid'    # python, mypy and pyflakes will fight over `(N|n)ame 'valid'`, just hope for the best
+    ...    (lintr).    # r
+    ...    `frob` is misspelt    # markdown
+    ...    Command terminated with space    # latex
     FOR    ${diagnostic}    IN    @{diagnostics}
         Wait Until Page Contains Diagnostic    [title*\="${diagnostic}"]    timeout=35s
     END

--- a/atest/suites/03_Notebook.robot
+++ b/atest/suites/03_Notebook.robot
@@ -54,11 +54,11 @@ Foreign Extractors
     Reset Application State
     Setup Notebook    Python    ${file}
     @{diagnostics} =    Create List
-    ...    Double quote to prevent globbing and word splitting    # bash, configured by spec.env
-    ...    ame 'valid'    # python, mypy and pyflakes will fight over `(N|n)ame 'valid'`, just hope for the best
-    ...    Trailing whitespace is superfluous.    # r
-    ...    `frob` is misspelt    # markdown
-    ...    Command terminated with space    # latex
+    ...    (shellcheck)    # bash, configured by spec.env
+    ...    (pyflakes)'    # Python
+    ...    (lintr)    # r
+    ...    (retext-spell)    # markdown
+    ...    (ChkTeX)    # latex
     FOR    ${diagnostic}    IN    @{diagnostics}
         Wait Until Page Contains Diagnostic    [title*\="${diagnostic}"]    timeout=35s
     END

--- a/atest/suites/03_Notebook.robot
+++ b/atest/suites/03_Notebook.robot
@@ -56,7 +56,7 @@ Foreign Extractors
     @{diagnostics} =    Create List
     ...    Double quote to prevent globbing and word splitting    # bash, configured by spec.env
     ...    ame 'valid'    # python, mypy and pyflakes will fight over `(N|n)ame 'valid'`, just hope for the best
-    ...    Remove trailing whitespace.    # r
+    ...    Trailing whitespace is superfluous.    # r
     ...    `frob` is misspelt    # markdown
     ...    Command terminated with space    # latex
     FOR    ${diagnostic}    IN    @{diagnostics}

--- a/atest/suites/05_Features/Highlights.robot
+++ b/atest/suites/05_Features/Highlights.robot
@@ -40,6 +40,7 @@ Highlights are changed when moving cursor between cells
     Press Keys    None    DOWN    # cursor to next cell, which is empty
     Should Not Highlight Any Tokens
     Press Keys    None    DOWN    # cursor to third cell (`|gist = 1`)
+    Press Keys    None    RIGHT    # (`g|ist = 1`)
     Should Highlight Token    gist
     Press Keys    None    DOWN    # cursor to third cell, second line (`|test `)
     Should Highlight Token    test

--- a/atest/suites/07_Configuration.robot
+++ b/atest/suites/07_Configuration.robot
@@ -92,7 +92,6 @@ Settings Should Change Editor Diagnostics
     Drag and Drop By Offset    ${tab}    0    100
     Wait Until Fully Initialized
     Open Diagnostics Panel
-    Drag and Drop By Offset    ${JLAB XP DOCK TAB}\[contains(., 'Diagnostics Panel')]    600    -200
     Click Element    ${JLAB XP DOCK TAB}\[contains(., 'Launcher')]/${close icon}
     IF    "${before}"
         Wait Until Page Contains Diagnostic    ${before diagnostic}    timeout=30s

--- a/atest/suites/07_Configuration.robot
+++ b/atest/suites/07_Configuration.robot
@@ -15,14 +15,14 @@ Python Nested
     Settings Should Change Editor Diagnostics    Python    style.py    pylsp
     ...    {"pylsp": {"plugins": {"flake8": {"enabled": true},"pyflakes": {"enabled": false}}}}
     ...    undefined name 'foo' (pyflakes)
-    ...    undefined name 'foo' (flake8)
+    ...    W291 trailing whitespace (flake8)
 
 Python Dotted
     [Documentation]    pyflakes is enabled by default, but flake8 is not
     Settings Should Change Editor Diagnostics    Python    style.py    pylsp
     ...    {"pylsp.plugins.flake8.enabled": true, "pylsp.plugins.pyflakes.enabled": false}
     ...    undefined name 'foo' (pyflakes)
-    ...    undefined name 'foo' (flake8)
+    ...    W291 trailing whitespace (flake8)
 
 Python (server-side via overrides JSON)
     [Documentation]    same as "Python" but changing the defaults in server specification via `overrides.json`

--- a/packages/jupyterlab-lsp/schema/plugin.json
+++ b/packages/jupyterlab-lsp/schema/plugin.json
@@ -82,5 +82,13 @@
       "description": "Whether to ask server to send logs with execution trace (for debugging). To see these messages, set loggingLevel to debug or log. Accepted values are: \"off\", \"messages\", \"verbose\". Servers are allowed to ignore this request."
     }
   },
+  "jupyter.lab.toolbars": {
+    "Notebook": [
+      {
+        "name": "lsp-status",
+        "rank": 900
+      }
+    ]
+  },
   "jupyter.lab.shortcuts": []
 }

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -481,6 +481,16 @@ export class StatusButtonExtension
   /**
    * For registration on notebook panels.
    */
+  createNewToolbarItem(): LSPStatus {
+    const item = this.createItem(false);
+    item.addClass('jp-ToolbarButton');
+    return item;
+  }
+
+  /**
+   * For registration on notebook panels.
+   * @deprecated use createNewToolbarItem() instead.
+   */
   createNew(
     panel: NotebookPanel,
     context: DocumentRegistry.IContext<INotebookModel>

--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -16,6 +16,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
+import { IToolbarWidgetRegistry } from '@jupyterlab/apputils';
 import { ILoggerRegistry } from '@jupyterlab/logconsole';
 import {
   ILSPDocumentConnectionManager,
@@ -82,7 +83,8 @@ export class LSPExtension {
     public translator: ITranslator,
     public userConsole: ILoggerRegistry | null,
     statusBar: IStatusBar | null,
-    formRegistry: IFormRendererRegistry | null
+    formRegistry: IFormRendererRegistry | null,
+    toolbarRegistry: IToolbarWidgetRegistry | null
   ) {
     const trans = (translator || nullTranslator).load('jupyterlab_lsp');
     this.languageServerManager = connectionManager.languageServerManager;
@@ -102,8 +104,10 @@ export class LSPExtension {
         rank: 1,
         isActive: () => this._isAnyActive()
       });
-    } else {
-      app.docRegistry.addWidgetExtension('Notebook', statusButtonExtension);
+    } else if (toolbarRegistry) {
+      toolbarRegistry.addFactory('Notebook', 'lsp-status', () =>
+        statusButtonExtension.createNewToolbarItem()
+      );
     }
 
     this._settingsSchemaManager = new SettingsSchemaManager({
@@ -220,7 +224,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
     ILSPLogConsole,
     ITranslator
   ],
-  optional: [ILoggerRegistry, IStatusBar, IFormRendererRegistry],
+  optional: [
+    ILoggerRegistry,
+    IStatusBar,
+    IFormRendererRegistry,
+    IToolbarWidgetRegistry
+  ],
   activate: (app, ...args) => {
     new LSPExtension(
       app,
@@ -231,7 +240,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
         ITranslator,
         ILoggerRegistry | null,
         IStatusBar | null,
-        IFormRendererRegistry | null
+        IFormRendererRegistry | null,
+        IToolbarWidgetRegistry | null
       ])
     );
   },

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_paths.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_paths.py
@@ -84,8 +84,8 @@ def test_normalize_windows_path_case(root_dir, expected_root_uri):  # pragma: no
     try:
         normalized = normalized_uri(root_dir)
     except FileNotFoundError as err:
-        if sys.version_info >= (3, 10):
-            # apparently, this triggers resolving the path on win/py3.10
+        if sys.version_info < (3, 12) and root_dir == "//VBOXSVR/shared-folder":
+            # see https://github.com/python/cpython/issues/136755
             return
         raise err
 


### PR DESCRIPTION
## References

Toolbar item can now be disabled

## Code changes

- Deprecates `StatusButtonExtension.createNew` that was used by docregistry to add toolbar items
- Adds `StatusButtonExtension.createNewToolbarItem` to be used with schema-based toolbar definitionn

## User-facing changes

Users can disable this icon when running in Notebook interface <img width="42" height="46" alt="image" src="https://github.com/user-attachments/assets/b8552b21-1a77-474f-9cf1-125b11263d67" />


<img width="400" height="1429" alt="Screenshot from 2025-07-18 09-39-06" src="https://github.com/user-attachments/assets/568acfc3-c173-4bee-9c35-a27c272d1c21" />


## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
